### PR TITLE
Fix GPU VRAM graph blank on Apple Silicon + refresh demo for v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <p align="center">
     <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue" alt="Platform">
     <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
-    <img src="https://img.shields.io/badge/status-v0.1-yellow" alt="Status">
+    <img src="https://img.shields.io/badge/version-v0.7.0-green" alt="Version">
   </p>
 </p>
 
@@ -15,7 +15,11 @@
 </p>
 
 <p align="center">
-  <img src="demo.gif" alt="SysWatch — Overview, CPU, Memory, Procs, Power, Services, Timeline, Insights" width="800">
+  <img src="demo.gif" alt="SysWatch — Overview, CPU, Memory, GPU, Procs, Power, Timeline, Insights" width="800">
+</p>
+
+<p align="center">
+  <strong>New in v0.7.0:</strong> the GPU tab — per-device utilization &amp; VRAM as ~120s time-series, with the renderer/tiler engine split on Apple Silicon, temp and power. No sudo.
 </p>
 
 ---
@@ -49,14 +53,13 @@ cargo build --release
 
 **Prerequisites:** Rust 1.75+. No system dependencies on Linux. macOS links against the system frameworks.
 
-> Crates.io / Homebrew / pre-built binaries land with v0.1 release.
-
 ## Usage
 
 ```bash
 syswatch                       # default 1Hz tick
 syswatch --tick 500            # 2Hz
 syswatch --tab procs           # boot straight into a tab
+syswatch --replay session.swr  # scrub a recorded session
 ```
 
 ### Keys
@@ -67,9 +70,15 @@ syswatch --tab procs           # boot straight into a tab
 Tab / Shift-Tab     →  Cycle tabs
 ↑ / ↓               →  Select row (Procs, Services)
 s                   →  Cycle sort (Procs, Services)
+/                   →  Filter processes
 ← / →               →  Scrub session backward / forward
 Home / End          →  Oldest sample / live
 p                   →  Pause
+g                   →  Graph style (bars / dots)
+t                   →  Cycle theme
+,                   →  Settings (tick, theme, btop-style fade)
+S / R               →  Snapshot to disk / record session
+?                   →  Help
 q / Ctrl-C          →  Quit
 ```
 
@@ -77,7 +86,7 @@ q / Ctrl-C          →  Quit
 
 **Insights tab.** Heuristic anomaly detection over the rolling session — swap thrash, runaway processes, disk full, memory pressure, high load, zombie parties — surfaced as plain-English cards with a suggested tab. The Overview's bottom strip and the tab bar's `[+]` badge keep them in sight from anywhere.
 
-**Session-wide scrubbing.** The Timeline tab's `←/→` rewinds the entire app — every panel transparently shows historical state. The session ring is the foundation Snapshot/Diff and Recording will sit on (v0.2).
+**Session-wide scrubbing.** The Timeline tab's `←/→` rewinds the entire app — every panel transparently shows historical state. `R` records a session to a `.swr` file; `--replay` scrubs it back later. `S` dumps the current snapshot to disk.
 
 **Honest about platform limits.** Where data needs sudo (`powermetrics` for fans, per-component power, GPU util on Apple Silicon) the tab shows what we *can* get for free and a one-line note about what's gated. Nothing is faked, nothing prompts.
 
@@ -89,15 +98,13 @@ q / Ctrl-C          →  Quit
 - **Not a logging product.** We surface OOM kills as a *signal* in Memory; we are not a log search UI.
 - **Not pretty charts for screenshots.** Block sparklines, real numbers, no smooth curves, no themes-of-the-week.
 
-## v0.1 scope
+## Scope
 
-All twelve tabs render real data on macOS and Linux. Cross-platform collection via `sysinfo`. Net interface counters and aggregate disk IO route through [`netwatch-sdk`](https://github.com/matthart1983/netwatch-sdk) so SysWatch and the NetWatch agent share a single source of truth for those parsers.
+All twelve tabs render real data on macOS and Linux. Cross-platform collection via `sysinfo`; aggregate disk IO routes through [`netwatch-sdk`](https://github.com/matthart1983/netwatch-sdk) so SysWatch and the NetWatch agent share a single source of truth. Recording/Replay (`R` / `--replay`), Settings (`,`), Help (`?`), process filter (`/`), themes (`t`), and the btop-style fade rendering are all live.
 
-**Deferred to v0.2** — Snapshot+Diff (footer S/D), Profiles (P), Recording/Replay (R), Settings (`,`), Help (`?`), filter (`/`).
+**No sudo, ever.** GPU utilization, VRAM, and the renderer/tiler split on Apple Silicon come from `ioreg` (`AGXAccelerator PerformanceStatistics`); GPU temperature, per-rail power, and fans come from IOReport + SMC. Linux reads sysfs (`/sys/class/drm`, thermal zones, hwmon). Where a figure genuinely needs elevated access, the tab says so rather than prompting.
 
-**Deferred behind sudo** — fans, per-component power, GPU temperature + per-rail power (all need `powermetrics`); macOS thermal zone temps (need IOReport private FFI). GPU **utilization** and used memory on Apple Silicon are no-sudo via ioreg's `AGXAccelerator PerformanceStatistics`. Linux gets thermal zones for free via sysfs.
-
-**Deferred behind features** — NVIDIA live GPU stats (`gpu-nvidia` cargo feature, `nvml-wrapper`), SMART disk health (`smart` cargo feature, `smartctl --json`).
+**Behind cargo features** — NVIDIA live GPU stats (`gpu-nvidia`, `nvml-wrapper`).
 
 ## Architecture
 
@@ -106,8 +113,9 @@ src/
 ├── main.rs              CLI + entry
 ├── app.rs               Event loop, tab state, scrub plumbing
 ├── collect/             One Collector per subsystem; Snapshot the wire format
-│   ├── collector.rs     sysinfo-backed CPU/Mem/Procs + dispatch
-│   ├── gpu.rs           system_profiler / sysfs DRM
+│   ├── collector.rs     sysinfo-backed CPU/Mem/Procs/Net + dispatch
+│   ├── gpu.rs           ioreg AGXAccelerator / sysfs DRM / nvml
+│   ├── macos_sampler.rs Shared IOReport + SMC worker (GPU/power/fans)
 │   ├── power.rs         ioreg / pmset / sysfs power_supply
 │   ├── services.rs      launchctl / systemctl
 │   └── ring.rs          Bounded history + nth_back for scrubbing
@@ -119,7 +127,7 @@ src/
     └── widgets.rs       block_bar, sparkline, panel
 ```
 
-Refresh model: 1 Hz fast loop for CPU/Mem/Procs/Net/IO; slow loops at 5 s for Power/Services (subprocess-heavy on macOS). The UI redraws on tick or keypress; CPU budget target is < 0.5% at idle.
+Refresh model: a 1 Hz fast loop reads CPU/Mem/Net/IO in-process every tick; the heavier collectors run on their own budgets — processes every ~1.5 s, Power/Services every 5 s, per-process bandwidth on a background thread — so the loop stays cheap regardless of tick rate. The UI redraws on tick or keypress.
 
 ## License
 

--- a/demo.tape
+++ b/demo.tape
@@ -1,5 +1,10 @@
 Output demo.gif
 
+# NOTE: this demo is recorded with the btop-style fade rendering enabled.
+# There's no CLI flag for it, so set `graph_fade = true` in
+# ~/.config/syswatch/config.toml before regenerating, or the charts/tables
+# render solid instead of faded.
+
 Require syswatch
 
 Set Shell "bash"
@@ -11,8 +16,15 @@ Set TypingSpeed 30ms
 Set Framerate 18
 Set Padding 10
 
-# Boot syswatch at a fast tick so the sparklines and counters move on camera.
+# Spin up background CPU work (yes) and a Metal GPU compute load (gpuload)
+# so the CPU per-core bars AND the new GPU util/VRAM graphs actually move on
+# camera. Start them first so there's already history by the time the tour
+# reaches those tabs. All hidden.
 Hide
+Type "yes > /dev/null & yes > /dev/null & yes > /dev/null &"
+Enter
+Type "/tmp/gpuload > /dev/null 2>&1 &"
+Enter
 Type "./target/release/syswatch --tick 500"
 Enter
 Sleep 4s
@@ -21,13 +33,18 @@ Show
 # [1] Overview — KPI strip, per-core grid, top procs, live insights.
 Sleep 5s
 
-# [2] CPU — aggregate sparkline + per-core utilization bars.
+# [2] CPU — aggregate sparkline + per-core utilization bars (busy now).
 Type "2"
 Sleep 4s
 
 # [3] Memory — RAM bar, swap, top RSS.
 Type "3"
-Sleep 4s
+Sleep 3s
+
+# [7] GPU — NEW in v0.7.0: per-device utilization + VRAM time-series
+# (~120s history), renderer/tiler engine split, live counters.
+Type "7"
+Sleep 6s
 
 # [6] Procs — sortable table; cycle the sort key so the table reshuffles.
 Type "6"
@@ -36,25 +53,16 @@ Type "s"
 Sleep 2s
 Type "s"
 Sleep 2s
-Down@200ms 6
-Sleep 2s
 
-# [8] Power — battery, source, throttle, draw.
+# [8] Power — battery, source, throttle, per-rail draw, fans.
 Type "8"
 Sleep 4s
-
-# [9] Services — sortable; switch to status sort to surface failed units.
-Type "9"
-Sleep 3s
-Type "s"
-Sleep 3s
 
 # [-] Timeline — stacked activity strips + scrubber. Walk back, then return live.
 Type "-"
 Sleep 3s
 Left@200ms 12
 Sleep 2s
-# Return to live (End key isn't supported by vhs; use right-arrow until at 0).
 Right@200ms 12
 Sleep 2s
 
@@ -67,3 +75,11 @@ Type "1"
 Sleep 4s
 
 Type "q"
+Sleep 500ms
+
+# Clean up the background load (hidden).
+Hide
+Type "pkill -x yes 2>/dev/null; pkill -f /tmp/gpuload 2>/dev/null; clear"
+Enter
+Sleep 500ms
+Show

--- a/src/app.rs
+++ b/src/app.rs
@@ -128,7 +128,16 @@ impl History {
                     .push(u);
             }
             // VRAM used fraction, same only-when-reported rule as util.
-            if let (Some(total), Some(used)) = (g.vram_total_bytes, g.vram_used_bytes) {
+            // Discrete GPUs report a dedicated VRAM total; Apple Silicon
+            // (unified memory) does not, so fall back to total system RAM —
+            // the real ceiling the GPU allocates against. Without this the
+            // VRAM history stays empty on every Apple Silicon Mac even though
+            // `vram_used_bytes` is reported every tick.
+            if let Some(used) = g.vram_used_bytes {
+                let total = g
+                    .vram_total_bytes
+                    .filter(|t| *t > 0)
+                    .unwrap_or(snap.mem.total_bytes);
                 if total > 0 {
                     self.gpu_vram_by_name
                         .entry(g.name.clone())
@@ -1064,6 +1073,32 @@ mod tests {
         });
         assert_eq!(
             h.gpu_vram_by_name.get("gpu0").map(|r| r.to_vec()),
+            Some(vec![0.25])
+        );
+    }
+
+    #[test]
+    fn gpu_vram_falls_back_to_system_memory_total() {
+        use crate::collect::{GpuTick, MemTick};
+        let mut h = History::new(10);
+        // Apple Silicon shape: no dedicated VRAM total, but used is reported,
+        // and the snapshot carries total system RAM. The fraction is
+        // recorded against system RAM so the history isn't perpetually empty.
+        h.push(&Snapshot {
+            mem: MemTick {
+                total_bytes: 32 * 1024 * 1024 * 1024,
+                ..Default::default()
+            },
+            gpus: vec![GpuTick {
+                name: "Apple M3 Pro".into(),
+                vram_total_bytes: None,
+                vram_used_bytes: Some(8 * 1024 * 1024 * 1024),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        assert_eq!(
+            h.gpu_vram_by_name.get("Apple M3 Pro").map(|r| r.to_vec()),
             Some(vec![0.25])
         );
     }

--- a/src/tabs/gpu.rs
+++ b/src/tabs/gpu.rs
@@ -89,7 +89,7 @@ fn draw_card(f: &mut Frame, area: Rect, gpu: &GpuTick, app: &App, snap: &Snapsho
     draw_series(
         f,
         chart_rows[1],
-        &vram_spec(gpu, app),
+        &vram_spec(gpu, app, snap.mem.total_bytes),
         app.graph_style,
         app.graph_opts(),
     );
@@ -146,7 +146,7 @@ fn util_spec<'a>(gpu: &'a GpuTick, app: &App) -> ChartSpec<'a> {
     }
 }
 
-fn vram_spec<'a>(gpu: &'a GpuTick, app: &App) -> ChartSpec<'a> {
+fn vram_spec<'a>(gpu: &'a GpuTick, app: &App, sys_total_bytes: u64) -> ChartSpec<'a> {
     let series = app
         .history
         .gpu_vram_by_name
@@ -155,7 +155,7 @@ fn vram_spec<'a>(gpu: &'a GpuTick, app: &App) -> ChartSpec<'a> {
         .unwrap_or_default();
     ChartSpec {
         label: "vram",
-        value: vram_value(gpu),
+        value: vram_value(gpu, sys_total_bytes),
         value_color: p::brand(),
         line_color: p::tx_rate(),
         series,
@@ -163,19 +163,42 @@ fn vram_spec<'a>(gpu: &'a GpuTick, app: &App) -> ChartSpec<'a> {
     }
 }
 
+/// The denominator the VRAM bar normalizes against: a discrete GPU's
+/// dedicated VRAM when reported, otherwise total system RAM (Apple Silicon
+/// unified memory). The bool flags the shared-memory case so the header can
+/// label it. Returns None when neither figure is available.
+fn vram_total_denominator(gpu: &GpuTick, sys_total_bytes: u64) -> Option<(u64, bool)> {
+    match gpu.vram_total_bytes {
+        Some(total) if total > 0 => Some((total, false)),
+        _ if sys_total_bytes > 0 => Some((sys_total_bytes, true)),
+        _ => None,
+    }
+}
+
 /// VRAM chart header: `used / total (pct%)`, degrading gracefully when only
-/// some of the figures are available.
-fn vram_value(gpu: &GpuTick) -> String {
-    match (gpu.vram_total_bytes, gpu.vram_used_bytes) {
-        (Some(total), Some(used)) if total > 0 => format!(
-            "{} / {} ({:.0}%)",
+/// some of the figures are available. On unified-memory systems the total is
+/// system RAM and gets a `shared` tag so the percentage isn't mistaken for a
+/// dedicated-VRAM figure.
+fn vram_value(gpu: &GpuTick, sys_total_bytes: u64) -> String {
+    match (
+        vram_total_denominator(gpu, sys_total_bytes),
+        gpu.vram_used_bytes,
+    ) {
+        (Some((total, shared)), Some(used)) => format!(
+            "{} / {}{} ({:.0}%)",
             human_bytes(used),
             human_bytes(total),
+            if shared { " shared" } else { "" },
             100.0 * used as f32 / total as f32
         ),
-        (Some(total), Some(used)) => format!("{} / {}", human_bytes(used), human_bytes(total)),
-        (Some(total), None) => format!("{} (used —)", human_bytes(total)),
-        _ => "—".into(),
+        (Some((total, shared)), None) => {
+            format!(
+                "{}{} (used —)",
+                human_bytes(total),
+                if shared { " shared" } else { "" }
+            )
+        }
+        (None, _) => "—".into(),
     }
 }
 
@@ -469,10 +492,13 @@ mod tests {
             vram_used_bytes: Some(12 * 1024 * 1024 * 1024),
             ..Default::default()
         };
+        // Discrete VRAM total wins; no shared tag.
+        let v = vram_value(&gpu, 64 * 1024 * 1024 * 1024);
+        assert!(v.contains("(25%)"), "expected 25% in {:?}", v);
         assert!(
-            vram_value(&gpu).contains("(25%)"),
-            "expected 25% in {:?}",
-            vram_value(&gpu)
+            !v.contains("shared"),
+            "discrete GPU shouldn't show shared in {:?}",
+            v
         );
         // Total but no used → honest about the missing figure.
         let partial = GpuTick {
@@ -480,7 +506,24 @@ mod tests {
             vram_used_bytes: None,
             ..Default::default()
         };
-        assert!(vram_value(&partial).contains("used —"));
+        assert!(vram_value(&partial, 0).contains("used —"));
+    }
+
+    #[test]
+    fn vram_value_falls_back_to_system_memory_when_no_discrete_total() {
+        // Apple Silicon: no dedicated VRAM total, but used is reported. The
+        // header normalizes against system RAM and tags it `shared`.
+        let gpu = GpuTick {
+            vram_total_bytes: None,
+            vram_used_bytes: Some(8 * 1024 * 1024 * 1024),
+            ..Default::default()
+        };
+        let v = vram_value(&gpu, 32 * 1024 * 1024 * 1024);
+        assert!(v.contains("(25%)"), "expected 25% of system RAM in {:?}", v);
+        assert!(v.contains("shared"), "expected shared tag in {:?}", v);
+        // Neither figure available → em dash.
+        let empty = GpuTick::default();
+        assert_eq!(vram_value(&empty, 0), "—");
     }
 
     #[test]


### PR DESCRIPTION
## What

Two related changes, surfaced while rebuilding the demo for v0.7.0:

### 1. Fix VRAM time-series staying blank on Apple Silicon
The v0.7.0 GPU tab records a VRAM-usage history, but only when the device reports a dedicated `vram_total_bytes`. Apple Silicon uses **unified memory** and never reports a discrete VRAM total, so `gpu_vram_by_name` stayed empty and the VRAM pane showed `no vram usage data` on **every Apple Silicon Mac** — even though `vram_used_bytes` (ioreg "In use system memory") is captured every tick.

Fix: fall back to **total system RAM** as the denominator when there's no discrete VRAM total — the real ceiling the GPU allocates against under unified memory. The header tags the shared case so the percentage isn't mistaken for dedicated VRAM:

```
vram   2.5 GB / 18.0 GB shared (14%)
```

New unit tests cover both the history fallback (`app.rs`) and the header formatting (`gpu.rs`).

### 2. Refresh the demo for v0.7.0
Regenerated `demo.gif` to feature the GPU tab (util + VRAM time-series, renderer/tiler engines), driving real background CPU + Metal GPU load so the per-core bars and GPU graphs actually move. The Insights tab closes the tour by flagging the synthetic load as a runaway process.

## Testing
- `cargo test` — 224 pass
- `cargo fmt --check` clean
- Verified live: VRAM pane now renders a populated, ramping series on an M3 Pro (18 GB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)