### PR TITLE
fix(gpu,insights): live AMD telemetry on multi-GPU hosts (#15) + no disk-full on read-only mounts (#9)

### DIFF
--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -293,6 +293,7 @@ impl Collector {
                 used_bytes: used,
                 available_bytes: avail,
                 usage_pct: pct * 100.0,
+                read_only: d.is_read_only(),
             });
         }
 

--- a/src/collect/gpu.rs
+++ b/src/collect/gpu.rs
@@ -112,12 +112,25 @@ const HINT_LINUX_INTEL: &str =
 pub struct GpuDiscovery {
     /// Cached at startup (subprocess on macOS is too slow to poll).
     pub devices: Vec<GpuTick>,
+    /// Parallel to `devices`: the real DRM `cardN` index per device on Linux
+    /// (`None` where there's no stable sysfs mapping, e.g. nvml NVIDIA
+    /// entries). Empty on other platforms. `refresh()` reads
+    /// `/sys/class/drm/cardN` live metrics by this true card number rather
+    /// than the device's position in the list, which mismatches on
+    /// hybrid/multi-GPU hosts where the discrete GPU isn't `card0` (issue #15).
+    #[allow(dead_code)]
+    card_indices: Vec<Option<u32>>,
 }
 
 impl GpuDiscovery {
     pub fn new() -> Self {
+        #[cfg(target_os = "linux")]
+        let (devices, card_indices) = discover_linux();
+        #[cfg(not(target_os = "linux"))]
+        let (devices, card_indices) = (discover(), Vec::new());
         Self {
-            devices: discover(),
+            devices,
+            card_indices,
         }
     }
 
@@ -167,16 +180,23 @@ impl GpuDiscovery {
         #[cfg(all(target_os = "linux", feature = "gpu-nvidia"))]
         nvidia::refresh(&mut out);
 
+        // Read live metrics by each device's *real* DRM card number, not its
+        // position in the list. On hybrid/multi-GPU hosts the discrete GPU is
+        // often card1 while card0 is the iGPU (or absent from the list), so a
+        // positional index reads the wrong (or a nonexistent) card and live
+        // telemetry comes back blank (issue #15).
         #[cfg(target_os = "linux")]
-        for (i, dev) in out.iter_mut().enumerate() {
+        for (dev, card_index) in out.iter_mut().zip(self.card_indices.iter()) {
+            let Some(card_idx) = card_index.map(|n| n as usize) else {
+                continue; // no stable sysfs card (e.g. nvml NVIDIA) — skip
+            };
             // gpu_busy_percent: AMDGPU + recent i915/xe both expose it.
-            if let Some(util) = read_linux_busy_percent(i) {
+            if let Some(util) = read_linux_busy_percent(card_idx) {
                 dev.util_pct = Some(util);
                 dev.live_data_hint = None;
             }
             if dev.vendor == "AMD" {
-                let device_path =
-                    std::path::PathBuf::from(format!("/sys/class/drm/card{}/device", i));
+                let device_path = amd_device_path(card_idx);
                 if let Some(used) = read_amdgpu_vram_bytes(&device_path.join("mem_info_vram_used"))
                 {
                     dev.vram_used_bytes = Some(used);
@@ -395,13 +415,15 @@ fn apply_perf_stats(stats: &mut MacGpuStats, body: &str) {
 }
 
 #[cfg(target_os = "linux")]
-fn discover() -> Vec<GpuTick> {
+fn discover_linux() -> (Vec<GpuTick>, Vec<Option<u32>>) {
     use std::fs;
     let mut out = Vec::new();
+    // Parallel to `out`: the real DRM `cardN` number for each device, so
+    // refresh() reads live metrics from the correct card (issue #15).
+    let mut card_idx: Vec<Option<u32>> = Vec::new();
     let Ok(entries) = fs::read_dir("/sys/class/drm") else {
-        return out;
+        return (out, card_idx);
     };
-    // Sort so the per-card index used by refresh() matches discovery order.
     let mut entries: Vec<_> = entries.flatten().collect();
     entries.sort_by_key(|e| e.file_name());
     for entry in entries {
@@ -411,6 +433,10 @@ fn discover() -> Vec<GpuTick> {
         if !name_str.starts_with("card") || name_str.contains('-') {
             continue;
         }
+        // Capture the true card number (card1 != position 0 on hybrid GPUs).
+        let Some(card_number) = parse_card_index(&name_str) else {
+            continue;
+        };
         let card_path = entry.path();
         let device_path = card_path.join("device");
         let vendor_id = fs::read_to_string(device_path.join("vendor"))
@@ -462,20 +488,35 @@ fn discover() -> Vec<GpuTick> {
             live_data_hint,
             last_submitter_pid: None,
         });
+        card_idx.push(Some(card_number));
     }
     // Replace the PCI-ID-only NVIDIA stubs with rich nvml-derived entries
     // when the feature is on and nvml init succeeds. nvml output supersedes
     // sysfs entirely for NVIDIA — no stable mapping between sysfs cardN and
-    // nvml index is exposed.
+    // nvml index is exposed. Drop the stubs and their card indices together so
+    // `out` and `card_idx` stay aligned, then append nvml entries with no
+    // sysfs card (`None`) — refresh() skips those and lets nvml drive them.
     #[cfg(feature = "gpu-nvidia")]
     {
         let nv = nvidia::discover();
         if !nv.is_empty() {
-            out.retain(|g| g.vendor != "NVIDIA");
-            out.extend(nv);
+            let mut kept_dev = Vec::with_capacity(out.len());
+            let mut kept_idx = Vec::with_capacity(card_idx.len());
+            for (dev, idx) in out.into_iter().zip(card_idx) {
+                if dev.vendor != "NVIDIA" {
+                    kept_dev.push(dev);
+                    kept_idx.push(idx);
+                }
+            }
+            for dev in nv {
+                kept_dev.push(dev);
+                kept_idx.push(None);
+            }
+            out = kept_dev;
+            card_idx = kept_idx;
         }
     }
-    out
+    (out, card_idx)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
@@ -488,6 +529,22 @@ fn read_linux_busy_percent(card_idx: usize) -> Option<f32> {
     let path = format!("/sys/class/drm/card{}/device/gpu_busy_percent", card_idx);
     let s = std::fs::read_to_string(path).ok()?;
     s.trim().parse::<f32>().ok()
+}
+
+/// Parse the DRM card number out of a `/sys/class/drm` entry name.
+/// `"card0" -> 0`, `"card12" -> 12`. Connector nodes (`"card0-HDMI-A-1"`)
+/// and render nodes (`"renderD128"`) return `None`.
+#[cfg(any(target_os = "linux", test))]
+fn parse_card_index(name: &str) -> Option<u32> {
+    name.strip_prefix("card")?.parse::<u32>().ok()
+}
+
+/// sysfs device directory for a given DRM card number. Centralized so the
+/// card-number → path mapping is exercised by tests (issue #15: this must
+/// follow the device's real card, not its position in the discovery list).
+#[cfg(any(target_os = "linux", test))]
+fn amd_device_path(card_idx: usize) -> std::path::PathBuf {
+    std::path::PathBuf::from(format!("/sys/class/drm/card{}/device", card_idx))
 }
 
 // ── AMDGPU sysfs helpers (linux | test for fixture-driven tests) ────────
@@ -711,6 +768,41 @@ mod tests {
         assert_eq!(stats[0].device_util_pct as i32, 42);
         assert_eq!(stats[0].renderer_util_pct, 0.0);
         assert_eq!(stats[0].in_use_system_memory, 0);
+    }
+
+    // ── DRM card-number mapping (issue #15) ── host-agnostic ──────────────
+
+    use super::{amd_device_path, parse_card_index};
+
+    #[test]
+    fn parses_card_number_from_drm_entry() {
+        assert_eq!(parse_card_index("card0"), Some(0));
+        assert_eq!(parse_card_index("card1"), Some(1));
+        assert_eq!(parse_card_index("card12"), Some(12));
+    }
+
+    #[test]
+    fn rejects_connector_and_render_nodes() {
+        // Connector nodes and render nodes must not be read as cards.
+        assert_eq!(parse_card_index("card0-HDMI-A-1"), None);
+        assert_eq!(parse_card_index("card1-DP-2"), None);
+        assert_eq!(parse_card_index("renderD128"), None);
+        assert_eq!(parse_card_index("card"), None);
+        assert_eq!(parse_card_index("controlD64"), None);
+    }
+
+    #[test]
+    fn device_path_follows_the_real_card_number() {
+        // The discrete GPU on a hybrid host is card1, not the position-0
+        // card0 — the live-metrics path must address card1 (issue #15).
+        assert_eq!(
+            amd_device_path(1),
+            std::path::PathBuf::from("/sys/class/drm/card1/device")
+        );
+        assert_eq!(
+            amd_device_path(0),
+            std::path::PathBuf::from("/sys/class/drm/card0/device")
+        );
     }
 
     // ── AMDGPU sysfs helpers ── exercised on any host via tempfile ────────

--- a/src/collect/model.rs
+++ b/src/collect/model.rs
@@ -41,6 +41,12 @@ pub struct DiskUsageTick {
     pub used_bytes: u64,
     pub available_bytes: u64,
     pub usage_pct: f32,
+    /// Mounted read-only (e.g. composefs/overlay roots on immutable distros,
+    /// squashfs, iso9660). A read-only filesystem at 100% is normal and
+    /// unactionable, so capacity warnings skip it (issue #9). `#[serde(default)]`
+    /// keeps older snapshots deserializing.
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]

--- a/src/insights/mod.rs
+++ b/src/insights/mod.rs
@@ -201,10 +201,13 @@ fn insight_runaway_proc(h: &History, snap: &Snapshot) -> Option<Insight> {
 
 /// Most-full mount above the warn/crit threshold.
 fn insight_disk_full(snap: &Snapshot) -> Option<Insight> {
+    // Skip read-only mounts: composefs/overlay roots on immutable distros
+    // (Fedora Atomic, ostree), squashfs, iso9660, etc. report 100% full by
+    // design and can never be cleared, so warning about them is noise (#9).
     let worst = snap
         .disks
         .iter()
-        .filter(|d| d.total_bytes > 0)
+        .filter(|d| d.total_bytes > 0 && !d.read_only)
         .max_by(|a, b| {
             a.usage_pct
                 .partial_cmp(&b.usage_pct)
@@ -217,7 +220,11 @@ fn insight_disk_full(snap: &Snapshot) -> Option<Insight> {
     } else {
         return None;
     };
-    let warn_count = snap.disks.iter().filter(|d| d.usage_pct >= 85.0).count();
+    let warn_count = snap
+        .disks
+        .iter()
+        .filter(|d| d.usage_pct >= 85.0 && !d.read_only)
+        .count();
     Some(Insight {
         severity,
         title: format!(
@@ -647,6 +654,16 @@ mod tests {
             used_bytes: ((used_pct / 100.0) * 100.0 * GIB as f32) as u64,
             available_bytes: ((1.0 - used_pct / 100.0) * 100.0 * GIB as f32) as u64,
             usage_pct: used_pct,
+            read_only: false,
+        }
+    }
+
+    /// A read-only mount (composefs/overlay root, squashfs, …) at `used_pct`.
+    fn disk_ro(mount: &str, fs_type: &str, used_pct: f32) -> DiskUsageTick {
+        DiskUsageTick {
+            fs_type: fs_type.into(),
+            read_only: true,
+            ..disk(mount, used_pct)
         }
     }
 
@@ -800,6 +817,43 @@ mod tests {
         let result = compute(&h, &s);
         let ins = first_with(&result, "full").expect("disk full insight expected");
         assert_eq!(ins.severity, Severity::Crit);
+    }
+
+    #[test]
+    fn disk_full_ignores_readonly_composefs_root() {
+        // Fedora Atomic / ostree roots are read-only composefs (fstype
+        // `overlay`) reported at 100% full — must not warn (issue #9).
+        let h = empty_history();
+        let s = snap(
+            MemTick::default(),
+            vec![],
+            vec![disk_ro("/", "overlay", 100.0)],
+        );
+        let result = compute(&h, &s);
+        assert!(
+            first_with(&result, "full").is_none(),
+            "read-only composefs root should not raise a disk-full insight"
+        );
+    }
+
+    #[test]
+    fn disk_full_picks_writable_mount_over_full_readonly_root() {
+        // A full read-only root must be skipped in favor of the genuinely
+        // actionable writable mount, not merely suppressed.
+        let h = empty_history();
+        let s = snap(
+            MemTick::default(),
+            vec![],
+            vec![disk_ro("/", "overlay", 100.0), disk("/var", 91.0)],
+        );
+        let result = compute(&h, &s);
+        let ins = first_with(&result, "full").expect("writable mount should warn");
+        assert_eq!(ins.severity, Severity::Warn);
+        assert!(
+            ins.title.contains("/var"),
+            "insight should target the writable mount, got: {}",
+            ins.title
+        );
     }
 
     // ── memory_pressure ──────────────────────────────────────────────────


### PR DESCRIPTION
Two correctness fixes, each verified against the code and reporter detail.

## #15 — AMD GPU live telemetry blank on hybrid/multi-GPU
The reporter's "hardcoded card0" was wrong in letter: `refresh()` addressed `/sys/class/drm/cardN` by each GPU's **position in the discovery list**, not its real card number. When the iGPU at `card0` isn't enumerated, the discrete GPU lands at index 0 and live util/VRAM/temp/power read the wrong (or nonexistent) card → static identity shows, telemetry blank. Fix: capture the true `cardN` at discovery (a vec kept parallel to the device list, aligned through the nvml NVIDIA reorder) and use it in `refresh()`. nvml-backed NVIDIA entries (no stable sysfs card) are skipped.

## #9 — composefs/read-only roots falsely flagged 100% full
Fedora Atomic / ostree roots are read-only composefs (fstype `overlay`) reported at 100% full, firing a bogus CRIT on every boot. Fix: carry the read-only flag through `DiskUsageTick` (from sysinfo's `is_read_only()`) and skip read-only mounts in the capacity insight.

## Verification
- 257/257 tests pass (5 new); `fmt` + clippy clean on changed lines
- Linux cross-check passes (default and `gpu-nvidia` features)

Closes #15
Closes #9