### PR TITLE
fix(ui): Procs/Memory UX — alignment, swap, detail toggle, update rate, CPU history (#11 #12 #13 #14 #10)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -32,6 +32,9 @@ pub struct Options {
     pub replay: Option<Vec<Snapshot>>,
 }
 
+/// Number of CPU-usage samples kept per process for the inline Procs sparkline.
+pub const PROC_CPU_SPARK_LEN: usize = 8;
+
 pub struct History {
     /// Aggregate CPU usage % (0..100), one sample per tick.
     pub cpu: Ring<f32>,
@@ -64,6 +67,10 @@ pub struct History {
     /// are pruned. Values are 0..100. The runaway-proc heuristic reads this
     /// to find processes whose load is sustained, not transient.
     pub proc_cpu_ewma: HashMap<u32, f32>,
+    /// Per-pid short CPU-usage history (0..1, raw cpu_pct/100) for the
+    /// btop-style inline sparkline in the Procs tab (issue #10). Bounded to
+    /// `PROC_CPU_SPARK_LEN` samples each; pruned to live pids every tick.
+    pub proc_cpu_history: HashMap<u32, Ring<f32>>,
     /// Per-pid billed-power EWMA (macOS) — smooths the 2s sampler so
     /// the energy-hog insight doesn't fire on one busy window.
     pub proc_power_ewma: HashMap<u32, f32>,
@@ -92,6 +99,7 @@ impl History {
             gpu_util_by_name: HashMap::new(),
             gpu_vram_by_name: HashMap::new(),
             proc_cpu_ewma: HashMap::new(),
+            proc_cpu_history: HashMap::new(),
             proc_power_ewma: HashMap::new(),
             proc_mem_track: HashMap::new(),
             session: Ring::new(cap),
@@ -169,6 +177,20 @@ impl History {
             next.insert(proc_.pid, ewma);
         }
         self.proc_cpu_ewma = next;
+
+        // Per-pid CPU-usage history for the Procs sparkline (issue #10).
+        // Move existing rings forward, append this tick's raw sample
+        // (cpu_pct/100, clamped), and drop rings for pids that have exited.
+        let mut next_hist: HashMap<u32, Ring<f32>> = HashMap::with_capacity(snap.procs.len());
+        for proc_ in &snap.procs {
+            let mut ring = self
+                .proc_cpu_history
+                .remove(&proc_.pid)
+                .unwrap_or_else(|| Ring::new(PROC_CPU_SPARK_LEN));
+            ring.push((proc_.cpu_pct / 100.0).clamp(0.0, 1.0));
+            next_hist.insert(proc_.pid, ring);
+        }
+        self.proc_cpu_history = next_hist;
 
         // Billed-power EWMA, same alpha and same prune-to-live rule.
         let mut next_power: HashMap<u32, f32> = HashMap::new();
@@ -369,6 +391,10 @@ pub struct App {
     pub snap: Option<Snapshot>,
     pub proc_sort: ProcSort,
     pub proc_sel: usize,
+    /// Whether the Procs tab shows its drill-in detail pane (which carries the
+    /// selected process's started date and other per-proc detail). Toggled
+    /// with `d`; off reclaims those rows for the process list (issue #13).
+    pub proc_show_detail: bool,
     pub service_sort: ServiceSort,
     pub service_sel: usize,
     pub insights: Vec<Insight>,
@@ -475,6 +501,7 @@ impl App {
             snap: None,
             proc_sort: ProcSort::Cpu,
             proc_sel: 0,
+            proc_show_detail: true,
             service_sort: ServiceSort::Name,
             service_sel: 0,
             insights: Vec::new(),
@@ -663,6 +690,11 @@ impl App {
                 // applied filter (if any) so the user can refine it.
                 self.proc_filter_input = true;
                 self.proc_filter_buf = self.proc_filter_active.clone().unwrap_or_default();
+            }
+            (KeyCode::Char('d'), _) if self.active == TabId::Procs => {
+                // Collapse/expand the drill-in detail pane to trade detail
+                // (incl. the started date) for more process rows (issue #13).
+                self.proc_show_detail = !self.proc_show_detail;
             }
             (KeyCode::Up, _) if self.active == TabId::Services => {
                 self.service_sel = self.service_sel.saturating_sub(1);
@@ -936,7 +968,14 @@ fn draw(f: &mut ratatui::Frame, app: &App, snap: &Snapshot) {
         ])
         .split(area);
 
-    chrome::draw_header(f, chunks[0], snap, app.live_state(), app.recorder.is_some());
+    chrome::draw_header(
+        f,
+        chunks[0],
+        snap,
+        app.live_state(),
+        app.recorder.is_some(),
+        app.user_config.tick_ms,
+    );
     let active_insights = app
         .insights
         .iter()
@@ -1033,6 +1072,48 @@ mod tests {
         h.push(&snap_with(vec![proc(1, 50.0)]));
         assert!(h.proc_cpu_ewma.contains_key(&1));
         assert!(!h.proc_cpu_ewma.contains_key(&2));
+    }
+
+    // ── per-pid CPU history sparkline (issue #10) ───────────────────────
+
+    #[test]
+    fn cpu_history_records_normalized_samples() {
+        let mut h = History::new(10);
+        h.push(&snap_with(vec![proc(1, 50.0)]));
+        h.push(&snap_with(vec![proc(1, 100.0)]));
+        let ring = h.proc_cpu_history.get(&1).expect("history for pid 1");
+        // cpu_pct/100, oldest→newest.
+        assert_eq!(ring.to_vec(), vec![0.5, 1.0]);
+    }
+
+    #[test]
+    fn cpu_history_clamps_above_100pct() {
+        // Multi-core aggregate cpu_pct can exceed 100; sparkline samples
+        // are clamped into 0..1 so the glyph mapping stays in range.
+        let mut h = History::new(10);
+        h.push(&snap_with(vec![proc(1, 350.0)]));
+        assert_eq!(h.proc_cpu_history.get(&1).unwrap().to_vec(), vec![1.0]);
+    }
+
+    #[test]
+    fn cpu_history_is_bounded_to_spark_len() {
+        let mut h = History::new(10);
+        for _ in 0..(PROC_CPU_SPARK_LEN + 5) {
+            h.push(&snap_with(vec![proc(1, 10.0)]));
+        }
+        assert_eq!(
+            h.proc_cpu_history.get(&1).unwrap().len(),
+            PROC_CPU_SPARK_LEN
+        );
+    }
+
+    #[test]
+    fn cpu_history_prunes_dead_pids() {
+        let mut h = History::new(10);
+        h.push(&snap_with(vec![proc(1, 10.0), proc(2, 10.0)]));
+        h.push(&snap_with(vec![proc(1, 10.0)]));
+        assert!(h.proc_cpu_history.contains_key(&1));
+        assert!(!h.proc_cpu_history.contains_key(&2));
     }
 
     #[test]

--- a/src/tabs/memory.rs
+++ b/src/tabs/memory.rs
@@ -14,18 +14,29 @@ use crate::ui::{
 };
 
 pub fn draw(f: &mut Frame, area: Rect, app: &App, snap: &Snapshot) {
-    let v = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(7),
-            Constraint::Length(7),
-            Constraint::Min(0),
-        ])
-        .split(area);
-
-    draw_ram_bar(f, v[0], snap, app.graph_style);
-    draw_swap(f, v[1], snap, app.graph_style);
-    draw_proc_breakdown(f, v[2], app, snap);
+    // Drop the SWAP panel entirely when no swap is configured — those 7 rows
+    // go to the process list instead (issue #12).
+    let has_swap = snap.mem.swap_total_bytes > 0;
+    if has_swap {
+        let v = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(7),
+                Constraint::Length(7),
+                Constraint::Min(0),
+            ])
+            .split(area);
+        draw_ram_bar(f, v[0], snap, app.graph_style);
+        draw_swap(f, v[1], snap, app.graph_style);
+        draw_proc_breakdown(f, v[2], app, snap);
+    } else {
+        let v = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(7), Constraint::Min(0)])
+            .split(area);
+        draw_ram_bar(f, v[0], snap, app.graph_style);
+        draw_proc_breakdown(f, v[1], app, snap);
+    }
 }
 
 fn draw_ram_bar(f: &mut Frame, area: Rect, snap: &Snapshot, style: GraphStyle) {
@@ -171,7 +182,8 @@ fn draw_proc_breakdown(f: &mut Frame, area: Rect, app: &App, snap: &Snapshot) {
     let mut header: Vec<Span> = vec![
         Span::styled(format!("{:>7} ", "PID"), header_style),
         Span::styled(format!("{:<10} ", "USER"), header_style),
-        Span::styled(format!("{:>6} ", "%MEM"), header_style),
+        // Width 5 to match the `{:>5.1}` data cell — see issue #11.
+        Span::styled(format!("{:>5} ", "%MEM"), header_style),
     ];
     if show_footprint {
         header.push(Span::styled(format!("{:>10} ", "FOOTPRNT"), header_style));

--- a/src/tabs/procs.rs
+++ b/src/tabs/procs.rs
@@ -14,13 +14,18 @@ use crate::ui::{
 };
 
 pub fn draw(f: &mut Frame, area: Rect, app: &App, snap: &Snapshot) {
+    // The drill-in pane is toggleable (`d`); hidden, its 9 rows go to the
+    // process list (issue #13).
+    let mut constraints = vec![
+        Constraint::Length(1), // sort strip / filter input
+        Constraint::Min(0),    // process table
+    ];
+    if app.proc_show_detail {
+        constraints.push(Constraint::Length(9)); // drill-in
+    }
     let v = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // sort strip / filter input
-            Constraint::Min(0),    // process table
-            Constraint::Length(9), // drill-in
-        ])
+        .constraints(constraints)
         .split(area);
 
     draw_sort_strip(f, v[0], app, snap);
@@ -31,7 +36,9 @@ pub fn draw(f: &mut Frame, area: Rect, app: &App, snap: &Snapshot) {
     );
     let total_mem = snap.mem.total_bytes.max(1);
     draw_table(f, v[1], app, &view, total_mem, snap.net_rates_estimated);
-    draw_drill_in(f, v[2], &view, app.proc_sel, total_mem);
+    if app.proc_show_detail {
+        draw_drill_in(f, v[2], &view, app.proc_sel, total_mem);
+    }
 }
 
 /// Filter then sort the proc list. `filter` is a case-insensitive
@@ -141,14 +148,14 @@ fn draw_sort_strip(f: &mut Frame, area: Rect, app: &App, snap: &Snapshot) {
     let count_text = if let Some(f) = app.proc_filter_active.as_deref() {
         let visible = filtered_sorted(&snap.procs, app.proc_sort, Some(f)).len();
         format!(
-            "    {}/{} procs  filter: \"{}\"   /:edit  s:sort  ↑↓:select",
+            "    {}/{} procs  filter: \"{}\"   /:edit  s:sort  d:detail  ↑↓:select",
             visible,
             snap.procs.len(),
             f
         )
     } else {
         format!(
-            "    {} procs   /:filter  s:sort  ↑↓:select",
+            "    {} procs   /:filter  s:sort  d:detail  ↑↓:select",
             snap.procs.len()
         )
     };
@@ -184,8 +191,12 @@ fn draw_table(
         Span::styled(format!("{:>7} ", "PID"), header_style()),
         Span::styled(format!("{:>7} ", "PPID"), header_style()),
         Span::styled(format!("{:<14} ", "USER"), header_style()),
-        Span::styled(format!("{:>6} ", "%CPU"), header_style()),
-        Span::styled(format!("{:>6} ", "%MEM"), header_style()),
+        // Width 5 to match the `{:>5.1}` data cells below — a width-6 header
+        // here drifted every column after USER one cell right (issue #11).
+        Span::styled(format!("{:>5} ", "%CPU"), header_style()),
+        // Inline CPU-usage history, btop-style (issue #10).
+        Span::styled(format!("{:<8} ", "CPU HIST"), header_style()),
+        Span::styled(format!("{:>5} ", "%MEM"), header_style()),
     ];
     // VIRT only when neither extras are shown — keeps the row from
     // sprawling past 120 cols when both NET and GPU are populated.
@@ -266,6 +277,10 @@ fn draw_table(
             Span::styled(
                 format!("{:>5.1} ", proc_.cpu_pct),
                 Style::default().fg(cpu_color).bg(row_bg),
+            ),
+            Span::styled(
+                format!("{} ", cpu_spark(app, proc_.pid)),
+                Style::default().fg(p::brand()).bg(row_bg),
             ),
             Span::styled(
                 format!("{:>5.1} ", mem_pct(proc_.mem_rss, total_mem)),
@@ -475,10 +490,27 @@ fn sort_procs(procs: &[ProcTick], key: ProcSort) -> Vec<ProcTick> {
     filtered_sorted(procs, key, None)
 }
 
+/// 8-cell CPU-usage sparkline for `pid`, right-aligned (newest sample at the
+/// right) and left-padded with spaces while the per-pid history is still
+/// filling. Empty (all spaces) for pids with no recorded history yet — e.g.
+/// while scrubbing a past snapshot whose pids have since exited (issue #10).
+fn cpu_spark(app: &App, pid: u32) -> String {
+    let width = crate::app::PROC_CPU_SPARK_LEN;
+    let samples = app
+        .history
+        .proc_cpu_history
+        .get(&pid)
+        .map(|r| r.to_vec())
+        .unwrap_or_default();
+    let glyphs = crate::ui::widgets::sparkline_string(&samples, app.graph_style);
+    let pad = width.saturating_sub(samples.len());
+    format!("{}{}", " ".repeat(pad), glyphs)
+}
+
 fn fill(width: usize, used: &str, show_net: bool, show_gpu: bool) -> String {
-    // Fixed: PID 7+1 + PPID 7+1 + USER 14+1 + %CPU 5+1 + %MEM 5+1
+    // Fixed: PID 7+1 + PPID 7+1 + USER 14+1 + %CPU 5+1 + CPU HIST 8+1 + %MEM 5+1
     //        STATE 5+1 + R/s 10+1 + W/s 10+1
-    let base = 7 + 1 + 7 + 1 + 14 + 1 + 5 + 1 + 5 + 1 + 5 + 1 + 10 + 1 + 10 + 1;
+    let base = 7 + 1 + 7 + 1 + 14 + 1 + 5 + 1 + 8 + 1 + 5 + 1 + 5 + 1 + 10 + 1 + 10 + 1;
     let virt_w = if !show_net && !show_gpu { 9 + 1 } else { 0 };
     let net_w = if show_net { 10 + 1 + 10 + 1 } else { 0 };
     let gpu_w = if show_gpu { 5 + 1 + 9 + 1 } else { 0 };

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -10,7 +10,27 @@ use crate::app::{LiveState, Snapshot, TabId, ALL_TABS};
 use crate::ui::graph::GraphStyle;
 use crate::ui::palette as p;
 
-pub fn draw_header(f: &mut Frame, area: Rect, snap: &Snapshot, live: LiveState, recording: bool) {
+/// Render the configured sample interval compactly: `1s`, `1.5s`, `250ms`.
+fn fmt_rate(tick_ms: u64) -> String {
+    if tick_ms >= 1000 {
+        if tick_ms.is_multiple_of(1000) {
+            format!("{}s", tick_ms / 1000)
+        } else {
+            format!("{:.1}s", tick_ms as f32 / 1000.0)
+        }
+    } else {
+        format!("{}ms", tick_ms)
+    }
+}
+
+pub fn draw_header(
+    f: &mut Frame,
+    area: Rect,
+    snap: &Snapshot,
+    live: LiveState,
+    recording: bool,
+    tick_ms: u64,
+) {
     let mut spans: Vec<Span> = Vec::new();
     spans.push(Span::styled(
         " \u{25cf}",
@@ -73,8 +93,20 @@ pub fn draw_header(f: &mut Frame, area: Rect, snap: &Snapshot, live: LiveState, 
                 .add_modifier(Modifier::BOLD),
         ));
     }
+    // Refresh rate sits between the live badge and the clock so the user can
+    // always see how fast the dashboard is sampling (issue #14).
     right_spans.push(Span::styled(
-        format!("\u{25cf} {}  {}", label, ts.format("%H:%M:%S")),
+        format!("\u{25cf} {}  ", label),
+        Style::default()
+            .fg(right_color)
+            .add_modifier(Modifier::BOLD),
+    ));
+    right_spans.push(Span::styled(
+        format!("\u{27f3} {}  ", fmt_rate(tick_ms)),
+        Style::default().fg(p::text_muted()),
+    ));
+    right_spans.push(Span::styled(
+        ts.format("%H:%M:%S").to_string(),
         Style::default()
             .fg(right_color)
             .add_modifier(Modifier::BOLD),
@@ -92,7 +124,9 @@ pub fn draw_header(f: &mut Frame, area: Rect, snap: &Snapshot, live: LiveState, 
     let right_area = Rect {
         x: area.x + area.width.saturating_sub(right_w),
         y: area.y,
-        width: right_w,
+        // Clamp to the buffer: on very narrow terminals right_w can exceed
+        // area.width, which would otherwise index past the buffer edge.
+        width: right_w.min(area.width),
         height: 1,
     };
 
@@ -332,5 +366,13 @@ mod tests {
         // Single-digit hours/minutes must zero-pad so column alignment
         // doesn't shift across ticks in the header.
         assert_eq!(format_uptime(3600), "01:00:00");
+    }
+
+    #[test]
+    fn fmt_rate_formats_sub_second_and_whole_and_fractional() {
+        assert_eq!(fmt_rate(250), "250ms");
+        assert_eq!(fmt_rate(1000), "1s");
+        assert_eq!(fmt_rate(2000), "2s");
+        assert_eq!(fmt_rate(1500), "1.5s");
     }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -104,6 +104,10 @@ const GROUPS: &[Group] = &[
                 keys: "/",
                 label: "Filter procs (Esc cancel, Enter apply)",
             },
+            Row {
+                keys: "d",
+                label: "Toggle drill-in detail pane (more list rows)",
+            },
         ],
     },
     Group {

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -94,8 +94,17 @@ pub fn sparkline_styled(
     color: ratatui::style::Color,
     style: GraphStyle,
 ) -> Line<'static> {
-    let s: String = samples.iter().map(|v| sparkline_glyph(*v, style)).collect();
-    Line::from(vec![Span::styled(s, Style::default().fg(color))])
+    Line::from(vec![Span::styled(
+        sparkline_string(samples, style),
+        Style::default().fg(color),
+    )])
+}
+
+/// Glyph string for `samples` (each 0..1), one cell per sample. Callers that
+/// need to composite the sparkline into a wider styled row (e.g. the Procs
+/// per-process CPU trend column) use this directly.
+pub fn sparkline_string(samples: &[f32], style: GraphStyle) -> String {
+    samples.iter().map(|v| sparkline_glyph(*v, style)).collect()
 }
 
 fn sparkline_glyph(v: f32, style: GraphStyle) -> char {


### PR DESCRIPTION
Five reported Procs/Memory UX issues.

- **#11** Column misalignment — `%CPU`/`%MEM` headers were width 6 but data width 5, drifting every column after USER one cell right (both Procs and Memory tabs). Headers now match the data width.
- **#12** Hide SWAP when none — the Memory tab drops the SWAP panel entirely when no swap is configured, giving its rows to the process list.
- **#13** Toggle detail pane — `d` on the Procs tab collapses the drill-in detail pane (which carries the started date) for more list rows. _Note: there's no standalone "date column" in the table; the detailed start date lives in the drill-in, so the toggle targets that pane. Happy to adjust if a different placement was intended._
- **#14** Show update rate — the header now shows the configured sample interval (e.g. `⟳ 1s`) between the live badge and the clock.
- **#10** Per-process CPU history — a btop-style inline CPU sparkline column in the Procs table, backed by a bounded per-pid history ring pruned to live pids each tick. (Per-core history, the "maybe also" part, is left for a follow-up.)

Also hardens `draw_header` against a latent panic: when the right-side text is wider than the terminal the right area could index past the buffer edge (surfaced by the wider rate badge at width 20).

## Verification
- 257/257 tests pass (5 new); `fmt` + clippy clean on changed lines
- Linux cross-check passes

Closes #11
Closes #12
Closes #13
Closes #14
Closes #10