### PR TITLE
fix(procs): add `f` as a layout-stable alias for the `/` filter key

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -685,9 +685,15 @@ impl App {
                 self.proc_sort = self.proc_sort.next();
                 self.proc_sel = 0;
             }
-            (KeyCode::Char('/'), _) if self.active == TabId::Procs => {
+            (KeyCode::Char('/') | KeyCode::Char('f'), _) if self.active == TabId::Procs => {
                 // Enter filter input mode. Pre-fill with the current
                 // applied filter (if any) so the user can refine it.
+                //
+                // `f` is an alternate trigger for `/`: on some keyboard
+                // layouts (e.g. ergol, issue #18) `/` lives on the AltGr
+                // layer and doesn't reliably reach us as a plain Char('/'),
+                // leaving search unreachable. `f` is a base-layer letter on
+                // every layout and matches btop/glances' filter key.
                 self.proc_filter_input = true;
                 self.proc_filter_buf = self.proc_filter_active.clone().unwrap_or_default();
             }
@@ -1336,5 +1342,45 @@ mod tests {
         assert_eq!(session.len(), 3);
         assert_eq!(session[0].procs[0].cpu_pct, 20.0);
         assert_eq!(session[2].procs[0].cpu_pct, 40.0);
+    }
+
+    // ── proc filter keybinding (issue #18) ──────────────────────────────
+
+    fn press(app: &mut App, c: char) {
+        app.handle_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+    }
+
+    #[test]
+    fn slash_and_f_both_open_the_procs_filter() {
+        // On layouts like ergol, `/` sits on the AltGr layer and can be
+        // unreachable, so `f` is an equivalent trigger. Both must open the
+        // filter, and only on the Procs tab.
+        for key in ['/', 'f'] {
+            let mut app = App::new(TabId::Procs, SyswatchConfig::default());
+            press(&mut app, key);
+            assert!(
+                app.proc_filter_input,
+                "'{key}' should open the procs filter"
+            );
+        }
+    }
+
+    #[test]
+    fn filter_trigger_is_inert_off_the_procs_tab() {
+        let mut app = App::new(TabId::Overview, SyswatchConfig::default());
+        press(&mut app, '/');
+        press(&mut app, 'f');
+        assert!(!app.proc_filter_input);
+    }
+
+    #[test]
+    fn f_types_into_the_filter_buffer_once_editing() {
+        // The `f` alias must not swallow a literal 'f' the user types as
+        // part of a filter term — input mode routes chars to the buffer.
+        let mut app = App::new(TabId::Procs, SyswatchConfig::default());
+        press(&mut app, '/');
+        assert!(app.proc_filter_input);
+        press(&mut app, 'f');
+        assert_eq!(app.proc_filter_buf, "f");
     }
 }

--- a/src/tabs/procs.rs
+++ b/src/tabs/procs.rs
@@ -148,14 +148,14 @@ fn draw_sort_strip(f: &mut Frame, area: Rect, app: &App, snap: &Snapshot) {
     let count_text = if let Some(f) = app.proc_filter_active.as_deref() {
         let visible = filtered_sorted(&snap.procs, app.proc_sort, Some(f)).len();
         format!(
-            "    {}/{} procs  filter: \"{}\"   /:edit  s:sort  d:detail  ↑↓:select",
+            "    {}/{} procs  filter: \"{}\"   / f:edit  s:sort  d:detail  ↑↓:select",
             visible,
             snap.procs.len(),
             f
         )
     } else {
         format!(
-            "    {} procs   /:filter  s:sort  d:detail  ↑↓:select",
+            "    {} procs   / f:filter  s:sort  d:detail  ↑↓:select",
             snap.procs.len()
         )
     };

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -101,7 +101,7 @@ const GROUPS: &[Group] = &[
                 label: "Cycle sort (cpu / mem / io / start / name / gpu / net)",
             },
             Row {
-                keys: "/",
+                keys: "/ or f",
                 label: "Filter procs (Esc cancel, Enter apply)",
             },
             Row {


### PR DESCRIPTION
Fixes #18.

On keyboard layouts where `/` lives on the AltGr layer (e.g. [ergol](https://ergol.org/)), the Procs filter was effectively unreachable because search was bound to the single literal `/` character. This binds `f` as an equivalent trigger — a base-layer letter on every layout, matching btop/glances' filter key — and advertises both in the Procs footer strip and the help popup.

- `src/app.rs` — filter opens on `/` **or** `f` (Procs tab only)
- `src/tabs/procs.rs` — footer hints now read `/ f:filter` / `/ f:edit`
- `src/ui/help.rs` — help row updated to `/ or f`
- 3 regression tests: both keys open the filter, the trigger is inert off the Procs tab, and `f` still types into the buffer once editing

`cargo test` → 265 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)