### PR TITLE
Count ZFS ARC as cached FS memory instead of used memory (Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Lite's temp / fan / power vitals depend on platform sensors: Linux reads `/sys/c
 
 **Behind cargo features** — NVIDIA live GPU stats (`gpu-nvidia`, `nvml-wrapper`).
 
-On Linux hosts with ZFS enabled, ZFS ARC is reclassified as cached memory instead of counting as used memory.
+**ZFS.** On Linux hosts running ZFS, the ARC is counted as available memory rather than used. It is a filesystem cache that gives pages back under pressure, so leaving it in `used` reads as permanent memory pressure on a machine that has none.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Lite's temp / fan / power vitals depend on platform sensors: Linux reads `/sys/c
 
 **Behind cargo features** — NVIDIA live GPU stats (`gpu-nvidia`, `nvml-wrapper`).
 
+On Linux hosts with ZFS enabled, ZFS ARC is reclassified as cached memory instead of counting as used memory.
+
 ## Architecture
 
 ```text

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -270,10 +270,19 @@ impl Collector {
     }
 
     fn collect_mem(&self) -> MemTick {
+        let total = self.sys.total_memory();
+        let mut used = self.sys.used_memory();
+        let mut available = self.sys.available_memory();
+        // Subtract ZFS ARC from used (it's reclaimable cache, not committed).
+        #[cfg(target_os = "linux")]
+        {
+            let arc = read_arc_size();
+            (used, available) = arc_adjust(used, available, arc);
+        }
         MemTick {
-            total_bytes: self.sys.total_memory(),
-            used_bytes: self.sys.used_memory(),
-            available_bytes: self.sys.available_memory(),
+            total_bytes: total,
+            used_bytes: used,
+            available_bytes: available,
             swap_total_bytes: self.sys.total_swap(),
             swap_used_bytes: self.sys.used_swap(),
             pressure_level: mem_pressure_level(),
@@ -592,6 +601,34 @@ fn collect_pressure() -> Option<PressureTick> {
     None
 }
 
+fn arc_adjust(used: u64, available: u64, arc_bytes: u64) -> (u64, u64) {
+    (used.saturating_sub(arc_bytes), available + arc_bytes)
+}
+
+/// Parse the `c` (ARC size) field from /proc/spl/kstat/zfs/arcstats text.
+fn parse_arcstats_c(text: &str) -> Option<u64> {
+    for line in text.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.first() == Some(&"c") {
+            return parts.get(2).and_then(|v| v.parse::<u64>().ok());
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn read_arc_size() -> u64 {
+    std::fs::read_to_string("/proc/spl/kstat/zfs/arcstats")
+        .ok()
+        .and_then(|s| parse_arcstats_c(&s))
+        .unwrap_or(0)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_arc_size() -> u64 {
+    0
+}
+
 /// macOS's own memory-pressure verdict, from
 /// `kern.memorystatus_vm_pressure_level`. Readable without elevation.
 ///
@@ -773,5 +810,50 @@ Threads:\t17
         assert!(threads.unwrap_or(0) >= 1);
         // Peak comes from rusage in proc_memory on macOS, not here.
         assert_eq!(peak, None);
+    }
+
+    // ── ZFS ARC adjustments ────────────────────────────────────────────
+
+    #[test]
+    fn arc_adjust_no_arc_preserves_values() {
+        // Zero ARC → no change to used or available.
+        assert_eq!(arc_adjust(100, 50, 0), (100, 50));
+    }
+
+    #[test]
+    fn arc_adjust_subtracts_from_used_adds_to_available() {
+        // 30 bytes of ARC moved from used → available.
+        assert_eq!(arc_adjust(100, 50, 30), (70, 80));
+    }
+
+    #[test]
+    fn arc_adjust_saturates_when_arc_exceeds_used() {
+        // ARC larger than used must not underflow — used clamps to 0.
+        assert_eq!(arc_adjust(100, 50, 150), (0, 200));
+    }
+
+    #[test]
+    fn parse_arcstats_c_extracts_c_from_real_output() {
+        let text = "\
+24 1 0x01 148 40256 5856356141 1344751450507729
+name                            type data
+hits                            4    2049659748
+iohits                          4    1195048
+misses                          4    4407338
+c                               4    66373946864
+c_min                           4    4217798400
+c_max                           4    133895806976
+size                            4    65967562640";
+        assert_eq!(parse_arcstats_c(text), Some(66373946864));
+    }
+
+    #[test]
+    fn parse_arcstats_c_returns_none_when_c_absent() {
+        assert_eq!(parse_arcstats_c("name  type  data\nhits  4  100\n"), None);
+    }
+
+    #[test]
+    fn parse_arcstats_c_returns_none_on_empty() {
+        assert_eq!(parse_arcstats_c(""), None);
     }
 }

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -278,7 +278,7 @@ impl Collector {
         #[cfg(target_os = "linux")]
         {
             let arc = read_arc_size();
-            (used, available) = arc_adjust(used, available, arc);
+            (used, available) = arc_adjust(used, available, total, arc);
         }
         MemTick {
             total_bytes: total,
@@ -602,8 +602,9 @@ fn collect_pressure() -> Option<PressureTick> {
     None
 }
 
-fn arc_adjust(used: u64, available: u64, arc_bytes: u64) -> (u64, u64) {
-    (used.saturating_sub(arc_bytes), available + arc_bytes)
+fn arc_adjust(used: u64, available: u64, total: u64, arc_bytes: u64) -> (u64, u64) {
+    let moved = arc_bytes.min(used);
+    (used - moved, (available + moved).min(total))
 }
 
 /// Parse the `size` (resident ARC size) field from /proc/spl/kstat/zfs/arcstats text.
@@ -826,19 +827,19 @@ Threads:\t17
     #[test]
     fn arc_adjust_no_arc_preserves_values() {
         // Zero ARC → no change to used or available.
-        assert_eq!(arc_adjust(100, 50, 0), (100, 50));
+        assert_eq!(arc_adjust(100, 50, 150, 0), (100, 50));
     }
 
     #[test]
     fn arc_adjust_subtracts_from_used_adds_to_available() {
         // 30 bytes of ARC moved from used → available.
-        assert_eq!(arc_adjust(100, 50, 30), (70, 80));
+        assert_eq!(arc_adjust(100, 50, 150, 30), (70, 80));
     }
 
     #[test]
     fn arc_adjust_clamps_when_arc_exceeds_used() {
-        // ARC larger than used must not underflow — used clamps to 0.
-        assert_eq!(arc_adjust(100, 50, 150), (0, 200));
+        // ARC larger than used: used clamps to 0, available clamps to total.
+        assert_eq!(arc_adjust(100, 50, 150, 150), (0, 150));
     }
 
     #[test]

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{Instant, SystemTime};
 
 use sysinfo::{Disks, Networks, Pid, ProcessRefreshKind, RefreshKind, System, Users};
@@ -277,8 +276,8 @@ impl Collector {
         // Subtract ZFS ARC from used (it's reclaimable cache, not committed).
         #[cfg(target_os = "linux")]
         {
-            let arc = read_arc_size();
-            (used, available) = arc_adjust(used, available, total, arc);
+            let arc = zfs::read_arc_size();
+            (used, available) = zfs::arc_adjust(used, available, total, arc);
         }
         MemTick {
             total_bytes: total,
@@ -602,60 +601,107 @@ fn collect_pressure() -> Option<PressureTick> {
     None
 }
 
-fn arc_adjust(used: u64, available: u64, total: u64, arc_bytes: u64) -> (u64, u64) {
-    let moved = arc_bytes.min(used);
-    (used - moved, (available + moved).min(total))
-}
-
-/// Parse `size` and `c_min` from /proc/spl/kstat/zfs/arcstats text.
-/// Returns (resident size, non-reclaimable floor).
-fn parse_arcstats(text: &str) -> Option<(u64, u64)> {
-    let mut size: Option<u64> = None;
-    let mut c_min: Option<u64> = None;
-    for line in text.lines() {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        let (Some(&name), Some(val_str)) = (parts.first(), parts.get(2)) else {
-            continue;
-        };
-        let val = val_str.parse::<u64>().ok().unwrap_or(0);
-        match name {
-            "size" => size = Some(val),
-            "c_min" => c_min = Some(val),
-            _ => {}
-        }
-    }
-    Some((size?, c_min.unwrap_or(0)))
-}
-
-/// Ticks between re-probes of the arcstats path.
-/// ZFS can load on demand; probing once at startup risks non-detection on long lived processes
-static ZFS_REPROBE_INTERVAL: u32 = 30;
-static ZFS_REPROBE_TICKS: AtomicU32 = AtomicU32::new(1);
-static ZFS_FOUND: AtomicBool = AtomicBool::new(false);
-
 #[cfg(target_os = "linux")]
-fn read_arc_size() -> u64 {
-    let path = std::path::Path::new("/proc/spl/kstat/zfs/arcstats");
-    let was_one = ZFS_REPROBE_TICKS.fetch_sub(1, Ordering::Relaxed) == 1;
-    if was_one {
-        ZFS_REPROBE_TICKS.store(ZFS_REPROBE_INTERVAL, Ordering::Relaxed);
-        let found = path.exists();
-        ZFS_FOUND.store(found, Ordering::Relaxed);
-        if !found {
+mod zfs {
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+    pub fn arc_adjust(used: u64, available: u64, total: u64, arc_bytes: u64) -> (u64, u64) {
+        let moved = arc_bytes.min(used);
+        (used - moved, (available + moved).min(total))
+    }
+
+    /// Parse `size` and `c_min` from /proc/spl/kstat/zfs/arcstats text.
+    /// Returns (resident size, non-reclaimable floor).
+    fn parse_arcstats(text: &str) -> Option<(u64, u64)> {
+        let mut size: Option<u64> = None;
+        let mut c_min: Option<u64> = None;
+        for line in text.lines() {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            let (Some(&name), Some(val_str)) = (parts.first(), parts.get(2)) else {
+                continue;
+            };
+            let val = val_str.parse::<u64>().ok().unwrap_or(0);
+            match name {
+                "size" => size = Some(val),
+                "c_min" => c_min = Some(val),
+                _ => {}
+            }
+        }
+        Some((size?, c_min.unwrap_or(0)))
+    }
+
+    /// Ticks between re-probes of the arcstats path.
+    /// ZFS can load on demand; probing once at startup risks non-detection on long lived processes
+    static REPROBE_INTERVAL: u32 = 30;
+    static REPROBE_TICKS: AtomicU32 = AtomicU32::new(1);
+    static FOUND: AtomicBool = AtomicBool::new(false);
+
+    pub fn read_arc_size() -> u64 {
+        let path = std::path::Path::new("/proc/spl/kstat/zfs/arcstats");
+        let was_one = REPROBE_TICKS.fetch_sub(1, Ordering::Relaxed) == 1;
+        if was_one {
+            REPROBE_TICKS.store(REPROBE_INTERVAL, Ordering::Relaxed);
+            let found = path.exists();
+            FOUND.store(found, Ordering::Relaxed);
+            if !found {
+                return 0;
+            }
+        } else if !FOUND.load(Ordering::Relaxed) {
             return 0;
         }
-    } else if !ZFS_FOUND.load(Ordering::Relaxed) {
-        return 0;
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| parse_arcstats(&s).map(|(size, c_min)| size.saturating_sub(c_min)))
+            .unwrap_or(0)
     }
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|s| parse_arcstats(&s).map(|(size, c_min)| size.saturating_sub(c_min)))
-        .unwrap_or(0)
-}
 
-#[cfg(not(target_os = "linux"))]
-fn read_arc_size() -> u64 {
-    0
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn arc_adjust_no_arc_preserves_values() {
+            assert_eq!(arc_adjust(100, 50, 150, 0), (100, 50));
+        }
+
+        #[test]
+        fn arc_adjust_subtracts_from_used_adds_to_available() {
+            assert_eq!(arc_adjust(100, 50, 150, 30), (70, 80));
+        }
+
+        #[test]
+        fn arc_adjust_clamps_when_arc_exceeds_used() {
+            assert_eq!(arc_adjust(100, 50, 150, 150), (0, 150));
+        }
+
+        #[test]
+        fn parse_arcstats_extracts_size_and_c_min_from_real_output() {
+            let text = "\
+24 1 0x01 148 40256 5856356141 1344751450507729
+name                            type data
+hits                            4    2049659748
+iohits                          4    1195048
+misses                          4    4407338
+c                               4    66373946864
+c_min                           4    4217798400
+c_max                           4    133895806976
+size                            4    65967562640";
+            assert_eq!(parse_arcstats(text), Some((65967562640, 4217798400)));
+        }
+
+        #[test]
+        fn parse_arcstats_returns_none_when_size_absent() {
+            assert_eq!(
+                parse_arcstats("name  type  data\nhits  4  100\n"),
+                None
+            );
+        }
+
+        #[test]
+        fn parse_arcstats_returns_none_on_empty() {
+            assert_eq!(parse_arcstats(""), None);
+        }
+    }
 }
 
 /// macOS's own memory-pressure verdict, from
@@ -839,50 +885,5 @@ Threads:\t17
         assert!(threads.unwrap_or(0) >= 1);
         // Peak comes from rusage in proc_memory on macOS, not here.
         assert_eq!(peak, None);
-    }
-
-    // ── ZFS ARC adjustments ────────────────────────────────────────────
-
-    #[test]
-    fn arc_adjust_no_arc_preserves_values() {
-        // Zero ARC → no change to used or available.
-        assert_eq!(arc_adjust(100, 50, 150, 0), (100, 50));
-    }
-
-    #[test]
-    fn arc_adjust_subtracts_from_used_adds_to_available() {
-        // 30 bytes of ARC moved from used → available.
-        assert_eq!(arc_adjust(100, 50, 150, 30), (70, 80));
-    }
-
-    #[test]
-    fn arc_adjust_clamps_when_arc_exceeds_used() {
-        // ARC larger than used: used clamps to 0, available clamps to total.
-        assert_eq!(arc_adjust(100, 50, 150, 150), (0, 150));
-    }
-
-    #[test]
-    fn parse_arcstats_extracts_size_and_c_min_from_real_output() {
-        let text = "\
-24 1 0x01 148 40256 5856356141 1344751450507729
-name                            type data
-hits                            4    2049659748
-iohits                          4    1195048
-misses                          4    4407338
-c                               4    66373946864
-c_min                           4    4217798400
-c_max                           4    133895806976
-size                            4    65967562640";
-        assert_eq!(parse_arcstats(text), Some((65967562640, 4217798400)));
-    }
-
-    #[test]
-    fn parse_arcstats_returns_none_when_size_absent() {
-        assert_eq!(parse_arcstats("name  type  data\nhits  4  100\n"), None);
-    }
-
-    #[test]
-    fn parse_arcstats_returns_none_on_empty() {
-        assert_eq!(parse_arcstats(""), None);
     }
 }

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -620,7 +620,9 @@ mod zfs {
             let (Some(&name), Some(val_str)) = (parts.first(), parts.get(2)) else {
                 continue;
             };
-            let val = val_str.parse::<u64>().ok().unwrap_or(0);
+            let Ok(val) = val_str.parse::<u64>() else {
+                continue;
+            };
             match name {
                 "size" => size = Some(val),
                 "c_min" => c_min = Some(val),
@@ -630,28 +632,34 @@ mod zfs {
         Some((size?, c_min.unwrap_or(0)))
     }
 
-    /// Ticks between re-probes of the arcstats path.
-    /// ZFS can load on demand; probing once at startup risks non-detection on long lived processes
-    static REPROBE_INTERVAL: u32 = 30;
+    /// Re-probes of the arcstats path, counted in *ticks* rather than
+    /// seconds: `tick_ms` is user-settable over 100..=5000, so this is a
+    /// re-probe every 3s at the fastest rate and every 150s at the slowest.
+    /// Probing once at startup would be cheaper and wrong — ZFS loads on
+    /// demand, so a module inserted after launch would never be noticed.
+    const REPROBE_INTERVAL: u32 = 30;
     static REPROBE_TICKS: AtomicU32 = AtomicU32::new(1);
     static FOUND: AtomicBool = AtomicBool::new(false);
 
     pub fn read_arc_size() -> u64 {
-        let path = std::path::Path::new("/proc/spl/kstat/zfs/arcstats");
-        let was_one = REPROBE_TICKS.fetch_sub(1, Ordering::Relaxed) == 1;
-        if was_one {
+        // Between probes a host without ZFS pays one relaxed load and a
+        // branch — no syscall at all.
+        let due = REPROBE_TICKS.fetch_sub(1, Ordering::Relaxed) == 1;
+        if due {
             REPROBE_TICKS.store(REPROBE_INTERVAL, Ordering::Relaxed);
-            let found = path.exists();
-            FOUND.store(found, Ordering::Relaxed);
-            if !found {
-                return 0;
-            }
         } else if !FOUND.load(Ordering::Relaxed) {
             return 0;
         }
-        std::fs::read_to_string(path)
-            .ok()
-            .and_then(|s| parse_arcstats(&s).map(|(size, c_min)| size.saturating_sub(c_min)))
+        // The read is the probe. A missing file and an unreadable one are
+        // the same answer here, so a preceding `exists()` would buy a
+        // second syscall and no extra information.
+        let Ok(text) = std::fs::read_to_string("/proc/spl/kstat/zfs/arcstats") else {
+            FOUND.store(false, Ordering::Relaxed);
+            return 0;
+        };
+        FOUND.store(true, Ordering::Relaxed);
+        parse_arcstats(&text)
+            .map(|(size, c_min)| size.saturating_sub(c_min))
             .unwrap_or(0)
     }
 
@@ -692,6 +700,15 @@ size                            4    65967562640";
         #[test]
         fn parse_arcstats_returns_none_when_size_absent() {
             assert_eq!(parse_arcstats("name  type  data\nhits  4  100\n"), None);
+        }
+
+        #[test]
+        fn parse_arcstats_skips_rows_whose_value_is_not_a_number() {
+            // The header row's third column is the literal word `data`, and a
+            // c_min we can't read means no floor rather than a floor of zero
+            // bytes read as a number.
+            let text = "name  type  data\nsize  4  4096\nc_min  4  not_a_number\n";
+            assert_eq!(parse_arcstats(text), Some((4096, 0)));
         }
 
         #[test]

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -607,15 +607,24 @@ fn arc_adjust(used: u64, available: u64, total: u64, arc_bytes: u64) -> (u64, u6
     (used - moved, (available + moved).min(total))
 }
 
-/// Parse the `size` (resident ARC size) field from /proc/spl/kstat/zfs/arcstats text.
-fn parse_arcstats_size(text: &str) -> Option<u64> {
+/// Parse `size` and `c_min` from /proc/spl/kstat/zfs/arcstats text.
+/// Returns (resident size, non-reclaimable floor).
+fn parse_arcstats(text: &str) -> Option<(u64, u64)> {
+    let mut size: Option<u64> = None;
+    let mut c_min: Option<u64> = None;
     for line in text.lines() {
         let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.first() == Some(&"size") {
-            return parts.get(2).and_then(|v| v.parse::<u64>().ok());
+        let (Some(&name), Some(val_str)) = (parts.first(), parts.get(2)) else {
+            continue;
+        };
+        let val = val_str.parse::<u64>().ok().unwrap_or(0);
+        match name {
+            "size" => size = Some(val),
+            "c_min" => c_min = Some(val),
+            _ => {}
         }
     }
-    None
+    Some((size?, c_min.unwrap_or(0)))
 }
 
 /// Ticks between re-probes of the arcstats path.
@@ -640,7 +649,7 @@ fn read_arc_size() -> u64 {
     }
     std::fs::read_to_string(path)
         .ok()
-        .and_then(|s| parse_arcstats_size(&s))
+        .and_then(|s| parse_arcstats(&s).map(|(size, c_min)| size.saturating_sub(c_min)))
         .unwrap_or(0)
 }
 
@@ -853,7 +862,7 @@ Threads:\t17
     }
 
     #[test]
-    fn parse_arcstats_size_extracts_size_from_real_output() {
+    fn parse_arcstats_extracts_size_and_c_min_from_real_output() {
         let text = "\
 24 1 0x01 148 40256 5856356141 1344751450507729
 name                            type data
@@ -864,16 +873,16 @@ c                               4    66373946864
 c_min                           4    4217798400
 c_max                           4    133895806976
 size                            4    65967562640";
-        assert_eq!(parse_arcstats_size(text), Some(65967562640));
+        assert_eq!(parse_arcstats(text), Some((65967562640, 4217798400)));
     }
 
     #[test]
-    fn parse_arcstats_size_returns_none_when_size_absent() {
-        assert_eq!(parse_arcstats_size("name  type  data\nhits  4  100\n"), None);
+    fn parse_arcstats_returns_none_when_size_absent() {
+        assert_eq!(parse_arcstats("name  type  data\nhits  4  100\n"), None);
     }
 
     #[test]
-    fn parse_arcstats_size_returns_none_on_empty() {
-        assert_eq!(parse_arcstats_size(""), None);
+    fn parse_arcstats_returns_none_on_empty() {
+        assert_eq!(parse_arcstats(""), None);
     }
 }

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -691,10 +691,7 @@ size                            4    65967562640";
 
         #[test]
         fn parse_arcstats_returns_none_when_size_absent() {
-            assert_eq!(
-                parse_arcstats("name  type  data\nhits  4  100\n"),
-                None
-            );
+            assert_eq!(parse_arcstats("name  type  data\nhits  4  100\n"), None);
         }
 
         #[test]

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::time::{Instant, SystemTime};
 
 use sysinfo::{Disks, Networks, Pid, ProcessRefreshKind, RefreshKind, System, Users};
@@ -616,8 +617,16 @@ fn parse_arcstats_c(text: &str) -> Option<u64> {
     None
 }
 
+/// Cached at startup — ZFS modules don't load/unload at runtime.
+static HAS_ZFS: OnceLock<bool> = OnceLock::new();
+
 #[cfg(target_os = "linux")]
 fn read_arc_size() -> u64 {
+    if !*HAS_ZFS.get_or_init(|| {
+        std::path::Path::new("/proc/spl/kstat/zfs/arcstats").exists()
+    }) {
+        return 0;
+    }
     std::fs::read_to_string("/proc/spl/kstat/zfs/arcstats")
         .ok()
         .and_then(|s| parse_arcstats_c(&s))

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -606,11 +606,11 @@ fn arc_adjust(used: u64, available: u64, arc_bytes: u64) -> (u64, u64) {
     (used.saturating_sub(arc_bytes), available + arc_bytes)
 }
 
-/// Parse the `c` (ARC size) field from /proc/spl/kstat/zfs/arcstats text.
-fn parse_arcstats_c(text: &str) -> Option<u64> {
+/// Parse the `size` (resident ARC size) field from /proc/spl/kstat/zfs/arcstats text.
+fn parse_arcstats_size(text: &str) -> Option<u64> {
     for line in text.lines() {
         let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.first() == Some(&"c") {
+        if parts.first() == Some(&"size") {
             return parts.get(2).and_then(|v| v.parse::<u64>().ok());
         }
     }
@@ -629,7 +629,7 @@ fn read_arc_size() -> u64 {
     }
     std::fs::read_to_string("/proc/spl/kstat/zfs/arcstats")
         .ok()
-        .and_then(|s| parse_arcstats_c(&s))
+        .and_then(|s| parse_arcstats_size(&s))
         .unwrap_or(0)
 }
 
@@ -836,13 +836,13 @@ Threads:\t17
     }
 
     #[test]
-    fn arc_adjust_saturates_when_arc_exceeds_used() {
+    fn arc_adjust_clamps_when_arc_exceeds_used() {
         // ARC larger than used must not underflow — used clamps to 0.
         assert_eq!(arc_adjust(100, 50, 150), (0, 200));
     }
 
     #[test]
-    fn parse_arcstats_c_extracts_c_from_real_output() {
+    fn parse_arcstats_size_extracts_size_from_real_output() {
         let text = "\
 24 1 0x01 148 40256 5856356141 1344751450507729
 name                            type data
@@ -853,16 +853,16 @@ c                               4    66373946864
 c_min                           4    4217798400
 c_max                           4    133895806976
 size                            4    65967562640";
-        assert_eq!(parse_arcstats_c(text), Some(66373946864));
+        assert_eq!(parse_arcstats_size(text), Some(65967562640));
     }
 
     #[test]
-    fn parse_arcstats_c_returns_none_when_c_absent() {
-        assert_eq!(parse_arcstats_c("name  type  data\nhits  4  100\n"), None);
+    fn parse_arcstats_size_returns_none_when_size_absent() {
+        assert_eq!(parse_arcstats_size("name  type  data\nhits  4  100\n"), None);
     }
 
     #[test]
-    fn parse_arcstats_c_returns_none_on_empty() {
-        assert_eq!(parse_arcstats_c(""), None);
+    fn parse_arcstats_size_returns_none_on_empty() {
+        assert_eq!(parse_arcstats_size(""), None);
     }
 }

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -271,14 +271,14 @@ impl Collector {
 
     fn collect_mem(&self) -> MemTick {
         let total = self.sys.total_memory();
-        let mut used = self.sys.used_memory();
-        let mut available = self.sys.available_memory();
+        let used = self.sys.used_memory();
+        let available = self.sys.available_memory();
         // Subtract ZFS ARC from used (it's reclaimable cache, not committed).
         #[cfg(target_os = "linux")]
-        {
+        let (used, available) = {
             let arc = zfs::read_arc_size();
-            (used, available) = zfs::arc_adjust(used, available, total, arc);
-        }
+            zfs::arc_adjust(used, available, total, arc)
+        };
         MemTick {
             total_bytes: total,
             used_bytes: used,

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{Instant, SystemTime};
 
 use sysinfo::{Disks, Networks, Pid, ProcessRefreshKind, RefreshKind, System, Users};
@@ -618,17 +618,27 @@ fn parse_arcstats_size(text: &str) -> Option<u64> {
     None
 }
 
-/// Cached at startup — ZFS modules don't load/unload at runtime.
-static HAS_ZFS: OnceLock<bool> = OnceLock::new();
+/// Ticks between re-probes of the arcstats path.
+/// ZFS can load on demand; probing once at startup risks non-detection on long lived processes
+static ZFS_REPROBE_INTERVAL: u32 = 30;
+static ZFS_REPROBE_TICKS: AtomicU32 = AtomicU32::new(1);
+static ZFS_FOUND: AtomicBool = AtomicBool::new(false);
 
 #[cfg(target_os = "linux")]
 fn read_arc_size() -> u64 {
-    if !*HAS_ZFS.get_or_init(|| {
-        std::path::Path::new("/proc/spl/kstat/zfs/arcstats").exists()
-    }) {
+    let path = std::path::Path::new("/proc/spl/kstat/zfs/arcstats");
+    let was_one = ZFS_REPROBE_TICKS.fetch_sub(1, Ordering::Relaxed) == 1;
+    if was_one {
+        ZFS_REPROBE_TICKS.store(ZFS_REPROBE_INTERVAL, Ordering::Relaxed);
+        let found = path.exists();
+        ZFS_FOUND.store(found, Ordering::Relaxed);
+        if !found {
+            return 0;
+        }
+    } else if !ZFS_FOUND.load(Ordering::Relaxed) {
         return 0;
     }
-    std::fs::read_to_string("/proc/spl/kstat/zfs/arcstats")
+    std::fs::read_to_string(path)
         .ok()
         .and_then(|s| parse_arcstats_size(&s))
         .unwrap_or(0)


### PR DESCRIPTION
syswatch does not know about the [ZFS Adaptive Replacement Cache](https://en.wikipedia.org/wiki/ZFS#Caching_mechanisms:_ARC,_L2ARC,_Transaction_groups,_ZIL,_SLOG,_Special_VDEV), a ZFS-specific page cache separate from the system one. It looks like used memory but is technically FS cache, thus it shouldn't count towards the notion of memory pressure.

This PR fixes syswatch to at least come to know about it and treat it as free memory, with no UI changes otherwise.

It does one attempt to open a ZFS related file in /proc, desisting for the remainder of process runtime if unsuccessful (so at worst one single read attempt per invocation for non-ZFS systems, same as for NVML init); otherwise, one proc file read per tick.

Technically, it isn't quite free memory either, though it deflates automatically with memory pressure. A more maximalist solution would be to actually discriminate and show ZFS-affected memory; see the example below for how [htop](https://github.com/htop-dev/htop) integrates it:

<img width="1259" height="183" alt="2026-08-09_14-09" src="https://github.com/user-attachments/assets/317f4302-a193-468c-ac3d-d140672250b9" />

This PR sits between that maximalist approach and just ignoring ZFS (resulting in bogus RAM pressure alerts), with minimal runtime impact for non-ZFS hosts.

If you prefer the maximalist approach, I'd be happy to take a stab at it in a further PR.

I used AI for the implementation; I do not have previous first hand experience with Rust, but I did fair due dilligence and ensured this is a sane approach with minimal static and runtime impact. I tested it locally on four machines for several days with no adverse side effects (correct output, no memory leaks, etc).
