### PR TITLE
perf: collector thread, dirty-only redraw, bounded subprocesses (13% → 4.3% idle CPU)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,31 +243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,26 +887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,7 +1136,6 @@ dependencies = [
  "libc",
  "memchr",
  "ntapi",
- "rayon",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,10 @@ path = "src/main.rs"
 [dependencies]
 ratatui = "0.29"
 crossterm = "0.28"
-sysinfo = "0.32"
+# default-features off drops `multithread`: sysinfo otherwise spins up a
+# rayon pool of one thread per core to refresh the process list, which was
+# most of syswatch's idle CPU and thread count (issue #4).
+sysinfo = { version = "0.32", default-features = false, features = ["system", "disk", "network", "user"] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
 anyhow = "1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,11 @@ use ratatui::Terminal;
 use std::collections::HashMap;
 
 pub use crate::collect::Snapshot;
-use crate::collect::{Collector, Ring};
+use crate::collect::{CollectorHandle, Ring};
+// Only the tests drive a `Collector` directly; live sampling goes through
+// the worker thread.
+#[cfg(test)]
+use crate::collect::Collector;
 use crate::config::SyswatchConfig;
 use crate::insights::{self, Insight};
 use crate::tabs;
@@ -1281,10 +1285,10 @@ pub fn run(opts: Options) -> Result<()> {
     // Skip collector setup in replay mode — IOReport / system_profiler
     // / ioreg probes do real work we don't need when there's no live
     // sampling to do.
-    let mut collector: Option<Collector> = if app.replay_mode {
+    let collector: Option<CollectorHandle> = if app.replay_mode {
         None
     } else {
-        Some(Collector::new(app.user_config.tick_ms))
+        Some(CollectorHandle::spawn(app.user_config.tick_ms))
     };
 
     enable_raw_mode()?;
@@ -1293,66 +1297,81 @@ pub fn run(opts: Options) -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut term = Terminal::new(backend)?;
 
-    // Force the first sample to fire immediately. After that we re-read
-    // the tick interval from `user_config` on every iteration so changes
-    // made through the settings popup take effect on the next cycle
-    // without a restart.
-    let mut last_tick = Instant::now() - Duration::from_secs(60);
+    // The collector thread owns sampling. This loop drains its channel,
+    // handles input, and redraws only when something changed: a new
+    // snapshot, a key, a resize, or a footer flash expiring. It wakes
+    // every POLL_SLICE because crossterm's poll is only woken by the
+    // terminal, not by the channel; the wake itself costs a `try_recv`
+    // and two atomic stores, not a frame.
+    const POLL_SLICE: Duration = Duration::from_millis(50);
+    let mut needs_draw = true;
+
     let res = loop {
-        // 100..=5000 ms — matches the validation in `config::validate`
-        // and `settings::apply_edit`. The clamp is defensive in case a
-        // hand-edited config slipped through.
-        let tick = Duration::from_millis(app.user_config.tick_ms.clamp(100, 5000));
-        if last_tick.elapsed() >= tick {
-            if !app.paused {
-                if let Some(c) = collector.as_mut() {
-                    let s = c.sample();
-                    app.history.push(&s);
-                    app.insights = insights::compute(&app.history, &s);
-                    // Advance Lite's threshold debounce once per *sample*.
-                    // Doing this at render time would tie the alert window
-                    // to the frame rate instead of the collection interval.
-                    let swap_rate =
-                        crate::ui::lite::swap_rate(&app.history, app.user_config.tick_ms);
-                    app.lite.alerts.update(&s, swap_rate);
-                    // Append to active recording (best-effort — we
-                    // don't want one bad write to brick the live UI).
-                    if let Some(rec) = app.recorder.as_mut() {
-                        if let Err(e) = rec.push(&s) {
-                            app.footer_flash = Some((
-                                format!("recording: {}", e),
-                                Instant::now() + Duration::from_secs(3),
-                            ));
-                            app.recorder = None;
-                        }
+        if let Some(c) = collector.as_ref() {
+            // The settings popup edits tick_ms live and `p` toggles pause;
+            // both are cheap to forward every iteration. The clamp
+            // matches `config::validate` and `settings::apply_edit`.
+            c.set_tick_ms(app.user_config.tick_ms.clamp(100, 5000));
+            c.set_paused(app.paused);
+
+            for s in c.drain() {
+                app.history.push(&s);
+                app.insights = insights::compute(&app.history, &s);
+
+                // Advance Lite's threshold debounce once per *sample*.
+                // Doing this at render time would tie the alert window
+                // to the frame rate instead of the collection interval.
+                let swap_rate = crate::ui::lite::swap_rate(&app.history, app.user_config.tick_ms);
+                app.lite.alerts.update(&s, swap_rate);
+
+                // Append to active recording (best-effort — we
+                // don't want one bad write to brick the live UI).
+                if let Some(rec) = app.recorder.as_mut() {
+                    if let Err(e) = rec.push(&s) {
+                        app.footer_flash = Some((
+                            format!("recording: {}", e),
+                            Instant::now() + Duration::from_secs(3),
+                        ));
+                        app.recorder = None;
                     }
-                    app.snap = Some(s);
                 }
-                // Replay mode: nothing to sample, the History ring is
-                // pre-populated and the scrubber drives displayed_snap.
+
+                app.snap = Some(s);
+                needs_draw = true;
             }
-            last_tick = Instant::now();
+            // Replay mode: nothing to sample, the History ring is
+            // pre-populated and the scrubber drives displayed_snap.
         }
 
-        // Lite's key handler needs the frame geometry to clamp scrolling,
-        // and only the renderer normally sees it.
-        if let Ok(size) = term.size() {
-            app.last_area = Rect::new(0, 0, size.width, size.height);
+        // A flash that just expired needs one more frame to disappear.
+        if let Some((_, expires)) = app.footer_flash {
+            if Instant::now() >= expires {
+                app.footer_flash = None;
+                needs_draw = true;
+            }
         }
 
-        if let Some(snap) = app.displayed_snap() {
-            term.draw(|f| draw(f, &app, snap))?;
+        if needs_draw {
+            // Lite's key handler needs the frame geometry to clamp
+            // scrolling, and only the renderer normally sees it.
+            if let Ok(size) = term.size() {
+                app.last_area = Rect::new(0, 0, size.width, size.height);
+            }
+            if let Some(snap) = app.displayed_snap() {
+                term.draw(|f| draw(f, &app, snap))?;
+            }
+            needs_draw = false;
         }
 
-        let timeout = tick.saturating_sub(last_tick.elapsed());
-        if event::poll(timeout.max(Duration::from_millis(33)))? {
+        if event::poll(POLL_SLICE)? {
             match event::read()? {
                 Event::Key(k) => {
                     if app.handle_key(k) {
                         break Ok::<(), anyhow::Error>(());
                     }
+                    needs_draw = true;
                 }
-                Event::Resize(_, _) => {}
+                Event::Resize(_, _) => needs_draw = true,
                 _ => {}
             }
         }

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::time::{Instant, SystemTime};
 
-use sysinfo::{Disks, Networks, Pid, ProcessRefreshKind, RefreshKind, System, Users};
+use sysinfo::{Disks, Networks, Pid, ProcessRefreshKind, RefreshKind, System, UpdateKind, Users};
 
 use super::gpu::GpuDiscovery;
 #[cfg(target_os = "macos")]
@@ -131,10 +131,22 @@ impl Collector {
             .map(|t| now.duration_since(t) >= PROCS_REFRESH)
             .unwrap_or(true);
         if procs_stale {
+            // Only the fields `collect_procs` reads, and at the same
+            // update cadence `everything()` used for them: user and cmd
+            // are `OnlyIfNotSet` because a process's UID and command
+            // line don't change after exec, so they're read once and
+            // cached by sysinfo itself. `everything()` also re-reads
+            // environ, exe, cwd and root for every process every 1.5s,
+            // which is real cost for fields we never look at.
             self.sys.refresh_processes_specifics(
                 sysinfo::ProcessesToUpdate::All,
                 true,
-                ProcessRefreshKind::everything(),
+                ProcessRefreshKind::new()
+                    .with_cpu()
+                    .with_memory()
+                    .with_disk_usage()
+                    .with_user(UpdateKind::OnlyIfNotSet)
+                    .with_cmd(UpdateKind::OnlyIfNotSet),
             );
             self.last_procs_refresh = Some(now);
         }

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -34,6 +34,14 @@ pub struct Collector {
     last_disk_write: u64,
     last_iface: HashMap<String, (u64, u64)>, // name -> (rx, tx)
     last_proc_io: HashMap<u32, (u64, u64)>,  // pid -> cumulative (read, written) bytes
+    /// Base per-process rows from the last actual refresh. `collect_procs`
+    /// re-reads `/proc/<pid>/status` per process (for thread count and peak
+    /// RSS) and clones every name/cmdline string, on top of walking every
+    /// entry in `self.sys.processes()` -- real cost, worth skipping on the
+    /// ticks where sysinfo's own cached process data hasn't changed at
+    /// all. Cloned and re-merged with the per-tick bw/gpu/mem detail on
+    /// every sample; only rebuilt when `procs_stale`.
+    cached_procs: Vec<ProcTick>,
     gpu: GpuDiscovery,
     power: PowerCollector,
     proc_bw: ProcessBandwidthCollector,
@@ -93,6 +101,7 @@ impl Collector {
             last_disk_write: 0,
             last_iface: HashMap::new(),
             last_proc_io: HashMap::new(),
+            cached_procs: Vec::new(),
             gpu: GpuDiscovery::new(),
             power: PowerCollector::new(),
             proc_bw: ProcessBandwidthCollector::new(),
@@ -130,8 +139,8 @@ impl Collector {
         // over every process) for a staleness bound most `top`-family
         // tools already accept.
         const PROCS_REFRESH: std::time::Duration = std::time::Duration::from_secs(3);
-        let procs_stale = self
-            .last_procs_refresh
+        let prior_refresh = self.last_procs_refresh;
+        let procs_stale = prior_refresh
             .map(|t| now.duration_since(t) >= PROCS_REFRESH)
             .unwrap_or(true);
         if procs_stale {
@@ -161,7 +170,26 @@ impl Collector {
         let mem = self.collect_mem();
         let (disks, disk_io) = self.collect_disks(dt_secs);
         let net = self.collect_net(dt_secs);
-        let mut procs = self.collect_procs(dt_secs);
+        // Every field `collect_procs` reads (sysinfo's cpu_usage/memory/
+        // disk_usage, plus a fresh /proc/<pid>/status read per process
+        // for thread count and peak RSS) is frozen until the next
+        // refresh -- sysinfo's own comment on `cpu_usage()` says as
+        // much, and it holds for the rest too. Recomputing it on every
+        // tick between refreshes reread ~500+ processes' worth of
+        // /proc/status for no new data, and computed io_read_rate /
+        // io_write_rate as (nonzero delta only on the refresh tick) /
+        // (per-tick dt) -- overstating the rate on that tick by
+        // roughly `PROCS_REFRESH / tick interval`, since the delta
+        // actually accumulated over the whole refresh interval, not
+        // one tick. Only rebuild on the tick that actually refreshed,
+        // using the true elapsed time since the previous refresh.
+        if procs_stale {
+            let refresh_dt = prior_refresh
+                .map(|t| now.duration_since(t).as_secs_f64().max(0.001))
+                .unwrap_or(dt_secs);
+            self.cached_procs = self.collect_procs(refresh_dt);
+        }
+        let mut procs = self.cached_procs.clone();
         // Per-PID bandwidth — measured (nettop) on macOS, attributed
         // elsewhere. Cached at REFRESH inside the collector so we only
         // pay the subprocess cost a few times a second even at 1Hz
@@ -854,6 +882,42 @@ fn interface_up_flags() -> HashMap<String, bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Two `sample()` calls well inside `PROCS_REFRESH` must reuse the
+    /// cached process list rather than re-walking `self.sys.processes()`
+    /// and re-reading `/proc/<pid>/status` for every process again.
+    /// Guards the fix where that re-walk ran on every tick regardless of
+    /// staleness (wasted work), and separately caused `io_read_rate` /
+    /// `io_write_rate` to spike on the refresh tick because the byte
+    /// delta was divided by the per-tick interval instead of the actual
+    /// time since the last refresh.
+    #[test]
+    fn procs_cache_is_reused_within_the_refresh_window() {
+        let mut c = Collector::new(1000);
+        let first = c.sample();
+        let refreshed_at = c.last_procs_refresh;
+        let cached_len = c.cached_procs.len();
+
+        // Immediately again -- nowhere near the 3s PROCS_REFRESH window.
+        let second = c.sample();
+
+        assert_eq!(
+            c.last_procs_refresh, refreshed_at,
+            "a sample well inside the refresh window re-triggered a process refresh"
+        );
+        assert_eq!(
+            c.cached_procs.len(),
+            cached_len,
+            "cached_procs changed size without a refresh"
+        );
+        // The snapshot handed to callers is a clone of the cache, not a
+        // recomputation -- same PIDs, same reported values.
+        let first_pids: std::collections::BTreeSet<u32> =
+            first.procs.iter().map(|p| p.pid).collect();
+        let second_pids: std::collections::BTreeSet<u32> =
+            second.procs.iter().map(|p| p.pid).collect();
+        assert_eq!(first_pids, second_pids);
+    }
 
     #[test]
     fn psi_parses_some_and_full() {

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -125,7 +125,11 @@ impl Collector {
         // full process scan every frame.
         self.sys.refresh_cpu_all();
         self.sys.refresh_memory();
-        const PROCS_REFRESH: std::time::Duration = std::time::Duration::from_millis(1500);
+        // 1.5s -> 3s: halves the amortized cost of the heaviest single
+        // stage in the collector (a full /proc scan for cpu/mem/disk_usage
+        // over every process) for a staleness bound most `top`-family
+        // tools already accept.
+        const PROCS_REFRESH: std::time::Duration = std::time::Duration::from_secs(3);
         let procs_stale = self
             .last_procs_refresh
             .map(|t| now.duration_since(t) >= PROCS_REFRESH)

--- a/src/collect/command.rs
+++ b/src/collect/command.rs
@@ -1,0 +1,117 @@
+//! Bounded subprocess execution for the collectors that shell out.
+//!
+//! Every external command syswatch runs (`systemctl`, `launchctl`,
+//! `ioreg`, `pmset`, `ss`, `lsof`, `nettop`, `system_profiler`) is
+//! something that can wedge: dbus down, systemd inside a container,
+//! IOKit busy. `Command::output()` would then block the caller for as
+//! long as the child hangs. Everything goes through `run_with_timeout`
+//! instead, which kills the child at the deadline and returns `None` so
+//! the collector keeps its cached value.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Budget for the periodic collectors (services, power, GPU stats,
+/// per-process bandwidth). Anything slower than this on a healthy host
+/// is already too slow to sample every few seconds.
+pub const PERIODIC_TIMEOUT: Duration = Duration::from_millis(1500);
+
+/// Budget for one-shot discovery at startup (`system_profiler`), which
+/// is legitimately slow on some Macs.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Run `program` with `args`, capturing stdout. Returns `None` if the
+/// program cannot be spawned, exits with an error we cannot read, or
+/// outlives `timeout` (in which case it is killed and reaped).
+///
+/// On timeout the reader thread is *not* joined: a grandchild that
+/// inherited the stdout pipe (`sh -c 'sleep 30'` leaves `sleep` alive
+/// after `sh` is killed) keeps the write end open, and joining would
+/// wait for it. The reader exits on its own once the pipe closes.
+pub fn run_with_timeout(program: &str, args: &[&str], timeout: Duration) -> Option<String> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let mut stdout = child.stdout.take()?;
+    let reader = std::thread::spawn(move || {
+        let mut text = String::new();
+        let _ = stdout.read_to_string(&mut text);
+        text
+    });
+
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                let _ = child.wait();
+                return reader.join().ok();
+            }
+            Ok(None) if started.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                drop(reader);
+                return None;
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                drop(reader);
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn captures_stdout_of_a_fast_command() {
+        let out = run_with_timeout("echo", &["hello"], Duration::from_secs(5));
+        assert_eq!(out.as_deref().map(str::trim), Some("hello"));
+    }
+
+    #[test]
+    fn missing_program_is_none() {
+        assert!(run_with_timeout("syswatch-no-such-binary", &[], Duration::from_secs(1)).is_none());
+    }
+
+    #[test]
+    fn grandchild_holding_the_pipe_does_not_extend_the_deadline() {
+        // `sh` is killed at the deadline but its `sleep` child inherits
+        // stdout and lives on; the call must still return promptly.
+        let started = Instant::now();
+        let out = run_with_timeout(
+            "sh",
+            &["-c", "sleep 30; echo never"],
+            Duration::from_millis(300),
+        );
+        assert!(out.is_none());
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "took {:?}, waited on the grandchild's pipe",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn hung_command_is_killed_at_the_deadline() {
+        let started = Instant::now();
+        let out = run_with_timeout("sleep", &["30"], Duration::from_millis(300));
+        assert!(out.is_none());
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "took {:?}, the child was not killed",
+            started.elapsed()
+        );
+    }
+}

--- a/src/collect/gpu.rs
+++ b/src/collect/gpu.rs
@@ -228,12 +228,14 @@ impl GpuDiscovery {
 
 #[cfg(target_os = "macos")]
 fn discover() -> Vec<GpuTick> {
-    use std::process::Command;
-    let output = Command::new("system_profiler")
-        .args(["SPDisplaysDataType", "-json"])
-        .output();
-    let Ok(out) = output else { return Vec::new() };
-    let text = String::from_utf8_lossy(&out.stdout);
+    use crate::collect::command::{run_with_timeout, DISCOVERY_TIMEOUT};
+    let Some(text) = run_with_timeout(
+        "system_profiler",
+        &["SPDisplaysDataType", "-json"],
+        DISCOVERY_TIMEOUT,
+    ) else {
+        return Vec::new();
+    };
     let Ok(parsed): Result<serde_json::Value, _> = serde_json::from_str(&text) else {
         return Vec::new();
     };
@@ -301,14 +303,15 @@ struct MacGpuStats {
 
 #[cfg(target_os = "macos")]
 fn collect_macos_gpu_stats() -> Vec<MacGpuStats> {
-    use std::process::Command;
-    let Ok(out) = Command::new("ioreg")
-        .args(["-r", "-d", "1", "-w", "0", "-c", "IOAccelerator"])
-        .output()
-    else {
+    use crate::collect::command::{run_with_timeout, PERIODIC_TIMEOUT};
+    let Some(text) = run_with_timeout(
+        "ioreg",
+        &["-r", "-d", "1", "-w", "0", "-c", "IOAccelerator"],
+        PERIODIC_TIMEOUT,
+    ) else {
         return Vec::new();
     };
-    parse_ioreg_perf_stats(&String::from_utf8_lossy(&out.stdout))
+    parse_ioreg_perf_stats(&text)
 }
 
 /// Parse one `MacGpuStats` per IOAccelerator block from ioreg output.

--- a/src/collect/mod.rs
+++ b/src/collect/mod.rs
@@ -1,4 +1,5 @@
 pub mod collector;
+pub mod command;
 #[cfg(target_os = "macos")]
 pub mod disk_macos;
 pub mod gpu;
@@ -12,7 +13,12 @@ pub mod proc_memory;
 pub mod ring;
 pub mod sanitize;
 pub mod services;
+pub mod worker;
 
+// The UI talks to the worker; `Collector` itself is only constructed on
+// that thread and in tests.
+#[cfg_attr(not(test), allow(unused_imports))]
 pub use collector::Collector;
 pub use model::*;
 pub use ring::Ring;
+pub use worker::CollectorHandle;

--- a/src/collect/power.rs
+++ b/src/collect/power.rs
@@ -79,32 +79,26 @@ impl PowerCollector {
 
 #[cfg(target_os = "macos")]
 fn sample_inner() -> PowerTick {
-    use std::process::Command;
+    use crate::collect::command::{run_with_timeout, PERIODIC_TIMEOUT};
 
     let mut tick = PowerTick::default();
 
     // Battery from ioreg AppleSmartBattery. We no longer derive
     // system_power_w from V·A here — the shared macOS sampler returns
     // the real per-rail total via IOReport in `PowerCollector::sample`.
-    if let Ok(out) = Command::new("ioreg")
-        .args(["-rn", "AppleSmartBattery"])
-        .output()
-    {
-        let text = String::from_utf8_lossy(&out.stdout);
+    if let Some(text) = run_with_timeout("ioreg", &["-rn", "AppleSmartBattery"], PERIODIC_TIMEOUT) {
         tick.battery = parse_macos_ioreg_battery(&text);
     }
 
     // Power source from pmset -g batt's first line: "Now drawing from 'X Power'".
-    if let Ok(out) = Command::new("pmset").args(["-g", "batt"]).output() {
-        let text = String::from_utf8_lossy(&out.stdout);
+    if let Some(text) = run_with_timeout("pmset", &["-g", "batt"], PERIODIC_TIMEOUT) {
         tick.source = parse_macos_pmset_source(&text);
     }
 
     // Thermal throttle from pmset -g therm. If the line "CPU_Speed_Limit = N"
     // is present we use N; if pmset only prints "no warning level recorded"
     // we know the system is fine → 100.
-    if let Ok(out) = Command::new("pmset").args(["-g", "therm"]).output() {
-        let text = String::from_utf8_lossy(&out.stdout);
+    if let Some(text) = run_with_timeout("pmset", &["-g", "therm"], PERIODIC_TIMEOUT) {
         tick.thermal_throttle_pct = Some(parse_macos_pmset_throttle(&text));
     }
 

--- a/src/collect/proc_bandwidth.rs
+++ b/src/collect/proc_bandwidth.rs
@@ -20,13 +20,12 @@
 //! sub-second tick rates.
 
 use std::collections::HashMap;
-use std::io::Read;
-use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
 use std::time::{Duration, Instant};
 
 use netwatch_sdk::collectors::connections::ConnectionDetail;
 
+use super::command::run_with_timeout;
 use super::model::InterfaceTick;
 
 const REFRESH: Duration = Duration::from_secs(2);
@@ -293,7 +292,7 @@ impl NettopState {
     fn sample(&mut self) -> Option<HashMap<u32, (f64, f64)>> {
         // -t external keeps loopback traffic out of the counters so
         // the numbers describe the wire, matching the host-level KPIs.
-        let text = run_command_with_timeout(
+        let text = run_with_timeout(
             "nettop",
             &[
                 "-P",
@@ -380,61 +379,20 @@ fn parse_nettop(text: &str) -> NettopCounters {
 
 #[cfg(target_os = "linux")]
 fn collect_process_connections() -> Vec<ConnectionDetail> {
-    let text = run_command_with_timeout("ss", &["-tunapi"], COMMAND_TIMEOUT).unwrap_or_default();
+    let text = run_with_timeout("ss", &["-tunapi"], COMMAND_TIMEOUT).unwrap_or_default();
     parse_ss_connections(&text)
 }
 
 #[cfg(target_os = "macos")]
 fn collect_process_connections() -> Vec<ConnectionDetail> {
-    let text =
-        run_command_with_timeout("lsof", &["-i", "-n", "-P", "-F", "pcPtTn"], COMMAND_TIMEOUT)
-            .unwrap_or_default();
+    let text = run_with_timeout("lsof", &["-i", "-n", "-P", "-F", "pcPtTn"], COMMAND_TIMEOUT)
+        .unwrap_or_default();
     parse_macos_lsof_connections(&text)
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn collect_process_connections() -> Vec<ConnectionDetail> {
     Vec::new()
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-fn run_command_with_timeout(program: &str, args: &[&str], timeout: Duration) -> Option<String> {
-    let mut child = Command::new(program)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-
-    let mut stdout = child.stdout.take()?;
-    let reader = std::thread::spawn(move || {
-        let mut text = String::new();
-        let _ = stdout.read_to_string(&mut text);
-        text
-    });
-
-    let started = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => {
-                let _ = child.wait();
-                return reader.join().ok();
-            }
-            Ok(None) if started.elapsed() >= timeout => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = reader.join();
-                return None;
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = reader.join();
-                return None;
-            }
-        }
-    }
 }
 
 #[cfg(any(target_os = "linux", test))]

--- a/src/collect/proc_gpu.rs
+++ b/src/collect/proc_gpu.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 /// The fdinfo walk touches every fd of every readable process, which
 /// is ~10 ms on a desktop; GPU attribution does not need to move
 /// faster than the other per-process collectors.
-const REFRESH: Duration = Duration::from_secs(2);
+const REFRESH: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ProcGpu {

--- a/src/collect/proc_gpu.rs
+++ b/src/collect/proc_gpu.rs
@@ -18,6 +18,12 @@
 //! not yet ready to take on for a single column.
 
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// The fdinfo walk touches every fd of every readable process, which
+/// is ~10 ms on a desktop; GPU attribution does not need to move
+/// faster than the other per-process collectors.
+const REFRESH: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ProcGpu {
@@ -33,6 +39,8 @@ pub struct ProcGpuCollector {
     /// level is what the column ultimately renders.
     #[cfg(target_os = "linux")]
     prev_engine_ns: HashMap<u32, (u64, std::time::Instant)>,
+    last_sample_at: Option<Instant>,
+    cached: HashMap<u32, ProcGpu>,
 }
 
 impl ProcGpuCollector {
@@ -40,7 +48,21 @@ impl ProcGpuCollector {
         Self::default()
     }
 
+    /// Per-PID GPU attribution, re-sampled at most every `REFRESH`;
+    /// between samples returns the cached map.
     pub fn sample(&mut self) -> HashMap<u32, ProcGpu> {
+        let stale = self
+            .last_sample_at
+            .map(|t| t.elapsed() >= REFRESH)
+            .unwrap_or(true);
+        if stale {
+            self.last_sample_at = Some(Instant::now());
+            self.cached = self.sample_now();
+        }
+        self.cached.clone()
+    }
+
+    fn sample_now(&mut self) -> HashMap<u32, ProcGpu> {
         #[cfg(target_os = "linux")]
         {
             let mut out = self.sample_linux_fdinfo();
@@ -61,6 +83,11 @@ impl ProcGpuCollector {
         let mut out: HashMap<u32, ProcGpu> = HashMap::new();
         let mut totals: HashMap<u32, (u64, u64)> = HashMap::new(); // pid → (engine_ns, mem_bytes)
 
+        // No DRM device, no DRM fds: skip the walk entirely (headless
+        // servers, containers).
+        if !std::path::Path::new("/dev/dri").exists() {
+            return out;
+        }
         let Ok(proc_iter) = fs::read_dir("/proc") else {
             return out;
         };

--- a/src/collect/proc_memory.rs
+++ b/src/collect/proc_memory.rs
@@ -27,10 +27,15 @@ use std::time::{Duration, Instant};
 
 use super::model::ProcTick;
 
-const REFRESH: Duration = Duration::from_secs(2);
+const REFRESH: Duration = Duration::from_secs(3);
 /// Detail is for the "what's eating my RAM" question — the top of the
 /// RSS ranking answers it; walking VMAs for every idle daemon doesn't.
-const MAX_PROCS: usize = 64;
+// The Memory tab renders at most `panel_height - 1` rows, well under
+// this on any normal terminal (this project's own demos are recorded
+// at 130x44). Leak tracking (`proc_mem_track`) keeps an entry once a
+// pid enters the top-N, so this only delays first detection for a
+// borderline grower rather than dropping coverage.
+const MAX_PROCS: usize = 48;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ProcMem {

--- a/src/collect/proc_memory.rs
+++ b/src/collect/proc_memory.rs
@@ -58,6 +58,12 @@ impl ProcMem {
 pub struct ProcMemCollector {
     last_sample_at: Option<Instant>,
     cached: HashMap<u32, ProcMem>,
+    /// RSS seen for each pid at its last `smaps_rollup` read. A process
+    /// whose RSS has not moved since is almost certainly unchanged in
+    /// PSS/private/shared too, so its cached detail is reused instead
+    /// of paying for another page-table walk. On an idle desktop that
+    /// is most of the top-N, most of the time.
+    last_rss: HashMap<u32, u64>,
 }
 
 impl ProcMemCollector {
@@ -65,6 +71,7 @@ impl ProcMemCollector {
         Self {
             last_sample_at: None,
             cached: HashMap::new(),
+            last_rss: HashMap::new(),
         }
     }
 
@@ -77,23 +84,38 @@ impl ProcMemCollector {
             .unwrap_or(true);
         if stale {
             self.last_sample_at = Some(Instant::now());
-            self.cached = collect_top(procs);
+            let (fresh, rss) = collect_top(procs, &self.cached, &self.last_rss);
+            self.cached = fresh;
+            self.last_rss = rss;
         }
         self.cached.clone()
     }
 }
 
-fn collect_top(procs: &[ProcTick]) -> HashMap<u32, ProcMem> {
+/// Detail for the top `MAX_PROCS` by RSS. Entries in `prev` whose RSS
+/// matches `prev_rss` are carried over without a read. Returns the new
+/// map and the RSS each entry was read (or carried) at.
+fn collect_top(
+    procs: &[ProcTick],
+    prev: &HashMap<u32, ProcMem>,
+    prev_rss: &HashMap<u32, u64>,
+) -> (HashMap<u32, ProcMem>, HashMap<u32, u64>) {
     let mut by_rss: Vec<(u32, u64)> = procs.iter().map(|p| (p.pid, p.mem_rss)).collect();
     by_rss.sort_by_key(|&(_, rss)| std::cmp::Reverse(rss));
     let mut out = HashMap::new();
-    for (pid, _) in by_rss.into_iter().take(MAX_PROCS) {
-        let m = collect_pid(pid);
+    let mut rss_seen = HashMap::new();
+    for (pid, rss) in by_rss.into_iter().take(MAX_PROCS) {
+        let reuse = prev_rss.get(&pid) == Some(&rss);
+        let m = match prev.get(&pid) {
+            Some(m) if reuse => *m,
+            _ => collect_pid(pid),
+        };
         if !m.is_empty() {
             out.insert(pid, m);
+            rss_seen.insert(pid, rss);
         }
     }
-    out
+    (out, rss_seen)
 }
 
 #[cfg(target_os = "linux")]

--- a/src/collect/services.rs
+++ b/src/collect/services.rs
@@ -15,6 +15,7 @@
 
 use std::time::{Duration, Instant};
 
+use crate::collect::command::{run_with_timeout, PERIODIC_TIMEOUT};
 use crate::collect::model::{ServiceStatus, ServiceTick};
 
 const REFRESH: Duration = Duration::from_secs(5);
@@ -38,7 +39,11 @@ impl ServicesCollector {
             .map(|t| t.elapsed() >= REFRESH)
             .unwrap_or(true);
         if stale {
-            self.cached = sample_inner();
+            // A hung or missing `systemctl` / `launchctl` keeps the last
+            // good list rather than blanking the tab.
+            if let Some(fresh) = sample_inner() {
+                self.cached = fresh;
+            }
             self.last_sample_at = Some(Instant::now());
         }
         self.cached.clone()
@@ -46,36 +51,31 @@ impl ServicesCollector {
 }
 
 #[cfg(target_os = "macos")]
-fn sample_inner() -> Vec<ServiceTick> {
-    use std::process::Command;
-    let Ok(out) = Command::new("launchctl").arg("list").output() else {
-        return Vec::new();
-    };
-    parse_launchctl_list(&String::from_utf8_lossy(&out.stdout))
+fn sample_inner() -> Option<Vec<ServiceTick>> {
+    let text = run_with_timeout("launchctl", &["list"], PERIODIC_TIMEOUT)?;
+    Some(parse_launchctl_list(&text))
 }
 
 #[cfg(target_os = "linux")]
-fn sample_inner() -> Vec<ServiceTick> {
-    use std::process::Command;
-    let Ok(out) = Command::new("systemctl")
-        .args([
+fn sample_inner() -> Option<Vec<ServiceTick>> {
+    let text = run_with_timeout(
+        "systemctl",
+        &[
             "list-units",
             "--type=service",
             "--all",
             "--no-legend",
             "--plain",
             "--no-pager",
-        ])
-        .output()
-    else {
-        return Vec::new();
-    };
-    parse_systemctl_list(&String::from_utf8_lossy(&out.stdout))
+        ],
+        PERIODIC_TIMEOUT,
+    )?;
+    Some(parse_systemctl_list(&text))
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn sample_inner() -> Vec<ServiceTick> {
-    Vec::new()
+fn sample_inner() -> Option<Vec<ServiceTick>> {
+    None
 }
 
 pub fn parse_launchctl_list(text: &str) -> Vec<ServiceTick> {

--- a/src/collect/services.rs
+++ b/src/collect/services.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 use crate::collect::command::{run_with_timeout, PERIODIC_TIMEOUT};
 use crate::collect::model::{ServiceStatus, ServiceTick};
 
-const REFRESH: Duration = Duration::from_secs(5);
+const REFRESH: Duration = Duration::from_secs(10);
 
 pub struct ServicesCollector {
     last_sample_at: Option<Instant>,

--- a/src/collect/worker.rs
+++ b/src/collect/worker.rs
@@ -1,0 +1,153 @@
+//! The collector thread.
+//!
+//! `Collector::sample` does real work — a sysinfo process refresh,
+//! `/proc` and sysfs reads, and on a budget `ss`, `systemctl`, `ioreg`
+//! and friends. Running it on the UI thread meant every one of those
+//! stalled input and rendering for its duration (issue #2). The
+//! `Collector` now lives on its own thread and hands finished
+//! `Snapshot`s to the UI over a channel; the UI never waits on it.
+//!
+//! The channel holds one snapshot. If the UI falls behind, the newest
+//! sample replaces the one it has not read yet rather than queueing.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use super::collector::Collector;
+use super::model::Snapshot;
+
+/// Knobs the UI thread can turn while the worker runs.
+struct Control {
+    tick_ms: AtomicU64,
+    paused: AtomicBool,
+    stop: AtomicBool,
+}
+
+/// UI-side handle to the collector thread.
+pub struct CollectorHandle {
+    rx: Receiver<Snapshot>,
+    ctrl: Arc<Control>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl CollectorHandle {
+    /// Spawn the collector thread. The `Collector` is constructed on
+    /// the worker so none of its platform handles ever cross threads.
+    /// The first sample is taken immediately.
+    pub fn spawn(tick_ms: u64) -> Self {
+        let (tx, rx) = mpsc::sync_channel::<Snapshot>(1);
+        let ctrl = Arc::new(Control {
+            tick_ms: AtomicU64::new(tick_ms),
+            paused: AtomicBool::new(false),
+            stop: AtomicBool::new(false),
+        });
+        let worker_ctrl = Arc::clone(&ctrl);
+        let join = std::thread::Builder::new()
+            .name("syswatch-collector".into())
+            .spawn(move || run_loop(tx, worker_ctrl, tick_ms))
+            .expect("spawn collector thread");
+        Self {
+            rx,
+            ctrl,
+            join: Some(join),
+        }
+    }
+
+    /// Take every snapshot the worker has produced since the last call,
+    /// oldest first. Never blocks.
+    pub fn drain(&self) -> Vec<Snapshot> {
+        let mut out = Vec::new();
+        while let Ok(s) = self.rx.try_recv() {
+            out.push(s);
+        }
+        out
+    }
+
+    /// Update the sample interval. Takes effect from the next tick.
+    pub fn set_tick_ms(&self, tick_ms: u64) {
+        self.ctrl.tick_ms.store(tick_ms, Ordering::Relaxed);
+    }
+
+    /// While paused the worker sleeps instead of sampling, so a paused
+    /// screen costs nothing and no snapshots pile up behind it.
+    pub fn set_paused(&self, paused: bool) {
+        self.ctrl.paused.store(paused, Ordering::Relaxed);
+    }
+}
+
+impl Drop for CollectorHandle {
+    fn drop(&mut self) {
+        self.ctrl.stop.store(true, Ordering::Relaxed);
+        // Do not join: a subprocess inside `sample()` is bounded by
+        // `command::PERIODIC_TIMEOUT`, but quitting should never wait
+        // for it. The thread dies with the process.
+        let _ = self.join.take();
+    }
+}
+
+fn run_loop(tx: SyncSender<Snapshot>, ctrl: Arc<Control>, tick_ms: u64) {
+    let mut collector = Collector::new(tick_ms);
+    // Poll the control flags at this granularity so pause, tick
+    // changes and quit are picked up promptly without busy-waiting.
+    const SLICE: Duration = Duration::from_millis(50);
+    let mut next_sample = Instant::now();
+    loop {
+        if ctrl.stop.load(Ordering::Relaxed) {
+            return;
+        }
+        let now = Instant::now();
+        if now < next_sample || ctrl.paused.load(Ordering::Relaxed) {
+            std::thread::sleep(SLICE.min(next_sample.saturating_duration_since(now).max(SLICE)));
+            continue;
+        }
+        let snap = collector.sample();
+        match tx.try_send(snap) {
+            Ok(()) => {}
+            Err(TrySendError::Full(snap)) => {
+                // UI has not consumed the previous one; replace it with
+                // the fresher sample rather than block the collector.
+                let _ = tx.try_send(snap);
+            }
+            Err(TrySendError::Disconnected(_)) => return,
+        }
+        let tick = Duration::from_millis(ctrl.tick_ms.load(Ordering::Relaxed).clamp(100, 5000));
+        next_sample = Instant::now() + tick;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_delivers_a_first_snapshot_promptly() {
+        let handle = CollectorHandle::spawn(1000);
+        let started = Instant::now();
+        let mut got = Vec::new();
+        while got.is_empty() && started.elapsed() < Duration::from_secs(10) {
+            got = handle.drain();
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert_eq!(got.len(), 1, "expected exactly one initial snapshot");
+        assert!(!got[0].cpu.per_core.is_empty() || got[0].host.cpu_cores > 0);
+    }
+
+    #[test]
+    fn paused_worker_stops_producing() {
+        let handle = CollectorHandle::spawn(100);
+        // Wait for the first sample, then pause.
+        let started = Instant::now();
+        while handle.drain().is_empty() && started.elapsed() < Duration::from_secs(10) {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        handle.set_paused(true);
+        // Anything already in flight lands within one slice.
+        std::thread::sleep(Duration::from_millis(200));
+        handle.drain();
+        std::thread::sleep(Duration::from_millis(400));
+        assert!(handle.drain().is_empty(), "paused worker kept sampling");
+    }
+}


### PR DESCRIPTION
## What

Phase 1 of a broader performance/positioning review: get syswatch's idle CPU down before touching anything else. A review found it at 12.9% of a core at the default 1 Hz tick, 26 threads, versus btop's 0.5% and 2 threads on the same 24-core box.

## Result

| | CPU (1 Hz, 20s) | RSS | threads |
|---|---|---|---|
| `main` | 12.9% | 24 MB | 26 |
| this PR | **4.2-4.5%** | 18 MB | 3 |
| btop, for reference | 0.5% | 8 MB | 2 |

3x improvement. Short of a self-imposed <2% target — see "What's left" below.

## Changes

- **Redraw only when dirty.** The loop redrew unconditionally every ~33ms; now it redraws on a new snapshot, a key, a resize, or a footer flash expiring.
- **Collector on its own thread** (new `collect/worker.rs`). Fixes #2 — a slow sample (wedged `systemctl`, a big `smaps_rollup` sweep) no longer freezes input or rendering. The UI drains a bounded channel; a fresher sample replaces an unread one rather than queueing.
- **Drop sysinfo's `multithread` feature.** Fixes #4 — that feature spun up a rayon pool sized to core count just to refresh the process list, which was 24 of the 26 threads.
- **Bound every subprocess** (new `collect/command.rs`). `systemctl`, `launchctl`, `ioreg`, `pmset`, `system_profiler` all go through a shared `run_with_timeout` now instead of a bare `Command::output()`, so a wedged binary can't hang the collector. `services.rs` keeps its last-known list on timeout instead of blanking the tab.
- **Trim the process refresh** to the fields actually read, instead of `ProcessRefreshKind::everything()`.
- **Cache per-process GPU and memory detail** on a 2s cadence instead of every tick, and reuse cached `smaps_rollup` data when a process's RSS hasn't moved.

Full rationale and a couple of things worth knowing (a grandchild-process pipe gotcha in the timeout helper, and a `UpdateKind::Always` vs `OnlyIfNotSet` correctness catch in the refresh trim) are in the commit message.

## Verified

- `cargo fmt --check` clean
- `cargo build --release` clean (3 pre-existing warnings, confirmed present on `main`, unaffected by this diff)
- `cargo test` — 358 passed, 1 ignored
- `cargo clippy --all-targets` — no new warnings
- Synthetic hung `systemctl` (sleeps 30s on PATH): first frame at ~1.9s, tab keys work throughout, `q` quits in 0.02s. On `main` this test result is not applicable — it freezes for the duration of the hang.

## What's left

Not aiming for <2% in this PR. Profiling after these changes puts `smaps_rollup` reads and the process refresh as the largest remaining stages. Getting further probably means only running the memory/GPU detail collectors when their tab is actually visible, but Insights' `mem_leak` check currently reads that data in the background on every tab, so that's a behavior change for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GESiHAfqp3qjvScRBjYu1A


---

**Update:** added a second commit widening refresh cadences (sysinfo process refresh 1.5s→3s, proc_mem/proc_gpu 2s→3s, services 5s→10s) and trimming `proc_mem`'s top-N from 64 to 48 (still well above what any tab renders). No behavior change to what's displayed. Measured with an interleaved A/B rather than trusting absolute before/after numbers on this shared box — direction is consistently favorable, magnitude ranged 6-16% additional reduction depending on the machine's background load at measurement time. Full detail in the second commit message.


---

**Update 2:** third commit fixes a correctness bug found while digging further: `collect_procs` (and its per-process `/proc/<pid>/status` read) ran on every tick regardless of whether sysinfo's own process data had actually refreshed, and its IO-rate calculation divided a delta that only changes on the refresh tick by the per-tick interval — overstating `io_read_rate`/`io_write_rate` by roughly `refresh_interval / tick_interval` right when a refresh lands (worse after this PR's own cadence widening, from ~1.5x to ~3x). Now cached and only recomputed on the actual refresh tick, with the correct elapsed-time-since-refresh used for the rate. No measurable change to the benchmarked CPU% (this stage was always small relative to the two already addressed) — kept for the correctness fix and reduced syscall volume, not a further perf win. Detail in the third commit message.
