### PR TITLE
fix: insights report real elapsed time, drop btop comparisons in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Home / End          →  Oldest sample / live
 p                   →  Pause
 g                   →  Graph style (bars / dots)
 t                   →  Cycle theme (incl. "terminal" — uses your terminal's own palette)
-,                   →  Settings (tick, theme, btop-style fade)
+,                   →  Settings (tick, theme, graph fade)
 S / R               →  Snapshot to disk / record session
 V                   →  Cycle views: Full → Lite → Dense
 L                   →  Jump straight to the Lite view
@@ -183,8 +183,8 @@ q  quit     p  pause    /  filter (name or user)
 ↵  detail   L  full     ?  help          ↑↓ / j k move   Esc unwind
 ```
 
-Recorded with `vhs demo-lite.tape` in the btop-style look — braille area plots
-(`g`) over the faint dot grid, with the right-bright / left-dim gradient — at
+Recorded with `vhs demo-lite.tape` — braille area plots (`g`) over the faint
+dot grid, with a right-bright / left-dim gradient — at
 `--tick 250` so the charts fill inside a GIF. They hold one sample per column
 and fill from the right in real time, so at the 1 Hz default the 78-column
 chart takes 78 seconds. Nothing is fast-forwarded: the axis label measures the
@@ -207,7 +207,7 @@ as the rest of syswatch.
 
 **Insights tab.** Heuristic anomaly detection over the rolling session — swap thrash, runaway processes, disk full, memory pressure, high load, zombie parties — surfaced as plain-English cards with a suggested tab. The Overview's bottom strip and the tab bar's `[+]` badge keep them in sight from anywhere.
 
-**Session-wide scrubbing.** The Timeline tab's `←/→` rewinds the entire app — every panel transparently shows historical state. `R` records a session to a `.swr` file; `--replay` scrubs it back later. `S` dumps the current snapshot to disk.
+**Live scrubbing, full-session recording.** The Timeline tab's `←/→` rewinds every panel at once over the last 120 samples it keeps live — two minutes at the default 1 Hz tick, less at a faster one. For anything longer, `R` records the whole session to a `.swr` file as it runs; `--replay` scrubs that back afterward with no length limit, and `S` dumps the current snapshot to disk.
 
 **Honest about platform limits.** Where data needs sudo (`powermetrics` for fans, per-component power, GPU util on Apple Silicon) the tab shows what we *can* get for free and a one-line note about what's gated. Nothing is faked, nothing prompts.
 
@@ -221,7 +221,7 @@ as the rest of syswatch.
 
 ## Scope
 
-All twelve tabs render real data on macOS and Linux. Cross-platform collection via `sysinfo`; aggregate disk IO routes through [`netwatch-sdk`](https://github.com/matthart1983/netwatch-sdk) so SysWatch and the NetWatch agent share a single source of truth. Recording/Replay (`R` / `--replay`), Settings (`,`), Help (`?`), table filter (`/` or `f`, on Procs / Memory / Services), themes (`t`), the Lite view (`L` / `--lite`), the Dense view (`V` / `--dense`), and the btop-style fade rendering are all live.
+All twelve tabs render real data on macOS and Linux. Cross-platform collection via `sysinfo`; aggregate disk IO routes through [`netwatch-sdk`](https://github.com/matthart1983/netwatch-sdk) so SysWatch and the NetWatch agent share a single source of truth. Recording/Replay (`R` / `--replay`), Settings (`,`), Help (`?`), table filter (`/` or `f`, on Procs / Memory / Services), themes (`t`), the Lite view (`L` / `--lite`), the Dense view (`V` / `--dense`), and the graph-fade rendering are all live.
 
 Lite's temp / fan / power vitals depend on platform sensors: Linux reads `/sys/class/hwmon`, `/sys/class/thermal` and RAPL; macOS needs IOKit/SMC access, so on Apple Silicon those three commonly render `--` while CPU, memory, disk and processes remain fully live.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -99,9 +99,13 @@ pub struct History {
     /// the energy-hog insight doesn't fire on one busy window.
     pub proc_power_ewma: HashMap<u32, f32>,
     /// Per-pid leak tracking over detailed memory (footprint on macOS,
-    /// private on Linux): pid → (baseline, ticks observed, latest).
+    /// private on Linux): pid → (baseline, first observed, latest). The
+    /// timestamp is `Snapshot::t` at first sighting, not a tick count --
+    /// `insight_mem_leak`'s "sustained growth" window is a real time
+    /// duration, honest across a live tick-rate change or a replay
+    /// recorded at a different rate than it was captured at.
     /// Only procs the memory sampler covers (top-N by RSS) are tracked.
-    pub proc_mem_track: HashMap<u32, (u64, u32, u64)>,
+    pub proc_mem_track: HashMap<u32, (u64, SystemTime, u64)>,
     /// Full session: every snapshot pushed in order. Bounded — sized to
     /// match the metric rings so scrubbing stays in sync. The Timeline tab
     /// drives scrubbing; other tabs read App::displayed_snap().
@@ -276,11 +280,10 @@ impl History {
             };
             self.proc_mem_track
                 .entry(proc_.pid)
-                .and_modify(|(_base, ticks, latest)| {
-                    *ticks += 1;
+                .and_modify(|(_base, _first_seen, latest)| {
                     *latest = metric;
                 })
-                .or_insert((metric, 1, metric));
+                .or_insert((metric, snap.t, metric));
         }
     }
 }

--- a/src/insights/mod.rs
+++ b/src/insights/mod.rs
@@ -5,6 +5,8 @@
 //!
 //! Read-only by design — Insights surface what to look at, never mutate.
 
+use std::time::Duration;
+
 use crate::app::{History, TabId};
 use crate::collect::Snapshot;
 
@@ -35,6 +37,30 @@ pub struct Insight {
 
 const MIB: u64 = 1024 * 1024;
 const GIB: u64 = 1024 * 1024 * 1024;
+
+/// Real elapsed time between `snap` (the current tick) and the sample at
+/// `baseline_idx` in the *oldest-to-newest* ordering a caller already used
+/// to pull a metric's own baseline value out of e.g. `h.swap.to_vec()`.
+///
+/// `h.session` is pushed in lockstep with every other per-tick ring (same
+/// `History::push` call, same length always), so the same index lines up
+/// exactly -- read here by reference via `nth_back` rather than cloning the
+/// ring, since each entry is a full `Snapshot` including every process's
+/// name and command line. Reads the actual recorded timestamps rather than
+/// assuming every tick took the configured interval, so the reported
+/// window stays honest across a live tick-rate change or a replay recorded
+/// at a different rate than it was captured at.
+fn elapsed_secs_since(h: &History, snap: &Snapshot, baseline_idx: usize) -> u64 {
+    let len = h.session.len();
+    if len == 0 {
+        return 0;
+    }
+    let n = len.saturating_sub(1).saturating_sub(baseline_idx);
+    h.session
+        .nth_back(n)
+        .map(|old| snap.t.duration_since(old.t).unwrap_or_default().as_secs())
+        .unwrap_or(0)
+}
 
 pub fn compute(h: &History, snap: &Snapshot) -> Vec<Insight> {
     let mut out: Vec<Insight> = Vec::new();
@@ -95,6 +121,7 @@ fn insight_swap_thrash(h: &History, snap: &Snapshot) -> Option<Insight> {
     let baseline_idx = history.len().saturating_sub(30);
     let baseline = history[baseline_idx];
     let growth = now.saturating_sub(baseline);
+    let elapsed_secs = elapsed_secs_since(h, snap, baseline_idx);
 
     let (severity, title) = if growth >= 512 * MIB {
         (
@@ -103,7 +130,7 @@ fn insight_swap_thrash(h: &History, snap: &Snapshot) -> Option<Insight> {
                 "swap thrash — {:.1} GB swapped, +{:.0} MB in last {}s",
                 now as f64 / GIB as f64,
                 growth as f64 / MIB as f64,
-                history.len() - baseline_idx
+                elapsed_secs
             ),
         )
     } else if growth >= 100 * MIB {
@@ -112,7 +139,7 @@ fn insight_swap_thrash(h: &History, snap: &Snapshot) -> Option<Insight> {
             format!(
                 "memory pressure — swap rising +{:.0} MB over last {}s",
                 growth as f64 / MIB as f64,
-                history.len() - baseline_idx
+                elapsed_secs
             ),
         )
     } else {
@@ -260,7 +287,8 @@ fn insight_memory_pressure(h: &History, snap: &Snapshot) -> Option<Insight> {
     if last_n < 3 {
         return None;
     }
-    let avg = recent[recent.len() - last_n..].iter().sum::<f32>() / last_n as f32;
+    let baseline_idx = recent.len() - last_n;
+    let avg = recent[baseline_idx..].iter().sum::<f32>() / last_n as f32;
     let severity = if avg >= 0.95 {
         Severity::Crit
     } else if avg >= 0.85 {
@@ -268,12 +296,13 @@ fn insight_memory_pressure(h: &History, snap: &Snapshot) -> Option<Insight> {
     } else {
         return None;
     };
+    let elapsed_secs = elapsed_secs_since(h, snap, baseline_idx);
     Some(Insight {
         severity,
         title: format!(
             "memory pressure — RAM {:.0}% used over last {}s",
             avg * 100.0,
-            last_n
+            elapsed_secs
         ),
         body: vec![
             format!(
@@ -387,6 +416,8 @@ fn insight_gpu_pegged(h: &History, snap: &Snapshot) -> Option<Insight> {
     } else {
         return None;
     };
+    let baseline_idx = recent.len() - last_n;
+    let elapsed_secs = elapsed_secs_since(h, snap, baseline_idx);
     let busiest = snap
         .gpus
         .iter()
@@ -398,7 +429,7 @@ fn insight_gpu_pegged(h: &History, snap: &Snapshot) -> Option<Insight> {
         severity,
         title: format!(
             "GPU pegged — {:.0}% util sustained over last {}s",
-            avg, last_n
+            avg, elapsed_secs
         ),
         body: vec![
             busiest,
@@ -558,16 +589,18 @@ fn insight_energy_hog(h: &History, snap: &Snapshot) -> Option<Insight> {
 /// and proportionally since we first saw it. RSS is deliberately not
 /// used: shared-page noise makes it cry wolf.
 fn insight_mem_leak(h: &History, snap: &Snapshot) -> Option<Insight> {
-    // ~2 minutes of sightings before judging; both absolute and
-    // relative growth required so neither big-but-stable nor
-    // tiny-but-doubling procs trip it.
-    const MIN_TICKS: u32 = 120;
+    // ~2 minutes of real elapsed time before judging -- not a tick
+    // count, so this doesn't fire after 120 ticks of a fast tick rate
+    // (well under 2 real minutes) or fail to fire after 2 real minutes
+    // of a slow one. Both absolute and relative growth required so
+    // neither big-but-stable nor tiny-but-doubling procs trip it.
+    const MIN_DURATION: Duration = Duration::from_secs(120);
     const MIN_GROWTH: u64 = 256 * MIB;
-    let (pid, (base, _ticks, latest)) = h
+    let (pid, (base, _first_seen, latest)) = h
         .proc_mem_track
         .iter()
-        .filter(|(_, (base, ticks, latest))| {
-            *ticks >= MIN_TICKS
+        .filter(|(_, (base, first_seen, latest))| {
+            snap.t.duration_since(*first_seen).unwrap_or_default() >= MIN_DURATION
                 && latest.saturating_sub(*base) >= MIN_GROWTH
                 && (*latest as f64) >= (*base as f64) * 1.3
         })
@@ -1073,6 +1106,114 @@ mod tests {
         // VRAM total unknown — can't compute fraction, must not fire.
         let s = snap_with_gpu(Some(50.0), Some(8 * GIB), None);
         assert!(first_with(&compute(&h, &s), "VRAM").is_none());
+    }
+
+    // ── elapsed_secs_since ───────────────────────────────────────────────
+
+    #[test]
+    fn elapsed_secs_since_reads_real_time_not_tick_count() {
+        // Five ticks spaced 4s apart -- a deliberately unusual rate so a
+        // tick-count-based answer (5, or 4) and the real-time answer (16)
+        // are obviously different numbers, not off-by-one variants of the
+        // same one.
+        let mut h = empty_history();
+        let t0 = std::time::SystemTime::UNIX_EPOCH;
+        for i in 0..5u64 {
+            h.push(&Snapshot {
+                t: t0 + Duration::from_secs(i * 4),
+                ..Default::default()
+            });
+        }
+        let now = Snapshot {
+            t: t0 + Duration::from_secs(4 * 4),
+            ..Default::default()
+        };
+        // baseline_idx 0 = the oldest of the 5 pushed ticks (t=0s).
+        assert_eq!(elapsed_secs_since(&h, &now, 0), 16);
+        // baseline_idx 3 = the 4th pushed tick (t=12s) -- 4s before now.
+        assert_eq!(elapsed_secs_since(&h, &now, 3), 4);
+    }
+
+    #[test]
+    fn elapsed_secs_since_on_empty_history_is_zero() {
+        let h = empty_history();
+        let now = Snapshot::default();
+        assert_eq!(elapsed_secs_since(&h, &now, 0), 0);
+    }
+
+    // ── mem_leak ─────────────────────────────────────────────────────────
+
+    fn leak_proc(pid: u32, footprint: u64) -> ProcTick {
+        ProcTick {
+            pid,
+            name: "leaky".into(),
+            mem_footprint: Some(footprint),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn mem_leak_does_not_fire_on_tick_count_alone_at_a_fast_tick_rate() {
+        // 120 ticks (the old MIN_TICKS) at 100ms each is only 12 real
+        // seconds -- must not fire despite hitting the old tick-count
+        // threshold, since growth and ratio both clear their gates too.
+        let mut h = empty_history();
+        let t0 = std::time::SystemTime::UNIX_EPOCH;
+        for i in 0..120u64 {
+            h.push(&Snapshot {
+                t: t0 + Duration::from_millis(i * 100),
+                procs: vec![leak_proc(42, 100 * MIB + i * 3 * MIB)],
+                ..Default::default()
+            });
+        }
+        let last = Snapshot {
+            t: t0 + Duration::from_millis(119 * 100),
+            procs: vec![leak_proc(42, 100 * MIB + 119 * 3 * MIB)],
+            ..Default::default()
+        };
+        assert!(first_with(&compute(&h, &last), "possible leak").is_none());
+    }
+
+    #[test]
+    fn mem_leak_fires_on_real_elapsed_time_with_few_ticks() {
+        // Only 5 ticks, but 30s apart -- 120s of real elapsed growth
+        // despite being far short of the old MIN_TICKS=120 tick count.
+        let mut h = empty_history();
+        let t0 = std::time::SystemTime::UNIX_EPOCH;
+        for i in 0..5u64 {
+            h.push(&Snapshot {
+                t: t0 + Duration::from_secs(i * 30),
+                procs: vec![leak_proc(7, 100 * MIB + i * 100 * MIB)],
+                ..Default::default()
+            });
+        }
+        let last = Snapshot {
+            t: t0 + Duration::from_secs(4 * 30),
+            procs: vec![leak_proc(7, 100 * MIB + 4 * 100 * MIB)],
+            ..Default::default()
+        };
+        let result = compute(&h, &last);
+        assert!(first_with(&result, "possible leak").is_some());
+    }
+
+    #[test]
+    fn mem_leak_does_not_fire_below_min_growth_even_over_time() {
+        let mut h = empty_history();
+        let t0 = std::time::SystemTime::UNIX_EPOCH;
+        for i in 0..5u64 {
+            // Only ~50 MiB of growth total -- under MIN_GROWTH (256 MiB).
+            h.push(&Snapshot {
+                t: t0 + Duration::from_secs(i * 30),
+                procs: vec![leak_proc(7, 100 * MIB + i * 10 * MIB)],
+                ..Default::default()
+            });
+        }
+        let last = Snapshot {
+            t: t0 + Duration::from_secs(4 * 30),
+            procs: vec![leak_proc(7, 100 * MIB + 4 * 10 * MIB)],
+            ..Default::default()
+        };
+        assert!(first_with(&compute(&h, &last), "possible leak").is_none());
     }
 
     // ── compute() ordering / capping ──────────────────────────────────────


### PR DESCRIPTION
## What

Phase 2 of the ongoing review/plan: make the tool honest about what it's actually measuring and showing, after phase 1 (#26, merged as v0.11.0) fixed the performance.

## Fixed: insights labeled tick counts as seconds

Four insight cards (swap thrash, memory pressure, GPU pegged, and the "~2 minute" memory-leak threshold) formatted or thresholded a raw tick count as if it were seconds. Only correct at exactly the 1 Hz default -- at any other tick rate, or in a replay recorded at a different rate than it's played back with, the number was wrong. Worst case: the leak detector's `MIN_TICKS=120` fired after 12 real seconds at a 250ms tick and took 10 real minutes at a 5000ms tick, despite its own comment claiming "~2 minutes" either way.

Fixed by reading real recorded timestamps (`Snapshot::t`) instead of threading `tick_ms` through and multiplying -- that would still be wrong across a live tick-rate change or a replay recorded at a different rate. A new `elapsed_secs_since` helper reads `History.session` by reference (`nth_back`, not `to_vec()` -- cloning full `Snapshot`s including every process's name/cmdline on every tick would undo phase 1's collector work). The leak tracker's tuple now stores `first_seen: SystemTime` instead of a tick counter.

5 new tests, including one that pins down the helper with a deliberately unusual 4s-per-tick spacing so a tick-count answer and the real-time answer are obviously different numbers, not off-by-one variants of each other. `insight_mem_leak` had zero test coverage before this -- it has 3 tests now, covering the fast-tick-shouldn't-fire case, the slow-tick-should-fire case, and a below-growth control.

## Fixed: two README overclaims

- Dropped "btop-style" from the three places the README compares its own rendering to btop's. It invites a head-to-head on the one axis (a live dashboard) where btop already wins on raw resource use -- the actual differentiator is memory: recording, scrubbing, and diagnosis over time, which btop doesn't do at all. Left the internal source comments crediting btop for a specific rendering technique alone -- that's honest attribution for maintainers, not positioning copy, so out of scope here.
- Corrected "session-wide scrubbing" to say what the Timeline ring actually holds: 120 samples live (two minutes at the default 1 Hz tick, less at a faster one), with `.swr` recording/replay named as the genuinely unbounded path past that.

## Verified

- `cargo fmt --check` clean
- `cargo build --release` clean (same 3 pre-existing warnings, confirmed unaffected by this diff via `git show main:...`)
- `cargo test` -- 364 passed / 1 ignored (was 359; 5 new tests)
- `cargo clippy --all-targets` -- identical total warning count (35) before and after; every warning in a touched file confirmed pre-existing at its pre-diff line number

## Not in this PR

Growing the session ring past 120 samples is deferred to the recorder work (phase 3) -- doing it now would just make live memory use worse before the snapshot format gets smaller. The README correction reflects the current, honest 120-sample number rather than fixing the underlying cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GESiHAfqp3qjvScRBjYu1A
