### PR TITLE
feat: stream replay from disk, add unattended recording (--record --keep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +147,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -270,6 +285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +383,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -737,6 +775,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +826,21 @@ checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
 dependencies = [
  "libloading",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1165,6 +1230,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "ctrlc",
  "dirs",
  "libc",
  "macpow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ postcard = { version = "1", features = ["use-std"] }
 # delta encoding in recording.rs — general-purpose compression still helps
 # once the identity/volatile split has removed the biggest redundancy.
 zstd = "0.14"
+# Clean Ctrl-C/SIGTERM handling for `syswatch --record`, so an
+# unattended recording flushes its current chunk instead of losing it
+# to an abrupt kill (Rust doesn't unwind on signal delivery).
+ctrlc = "3"
 
 # Linux NVIDIA support is opt-in: enabling `gpu-nvidia` links libnvidia-ml,
 # which only ships on hosts with the proprietary driver installed.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ syswatch --lite                # the one-screen Lite view
 syswatch --tick 500            # 2Hz
 syswatch --tab procs           # boot straight into a tab
 syswatch --replay session.swr  # scrub a recorded session
+syswatch --record --keep 24h   # unattended recording, no TUI (see below)
 ```
 
 ### Keys
@@ -209,19 +210,21 @@ as the rest of syswatch.
 
 **Live scrubbing, full-session recording.** The Timeline tab's `←/→` rewinds every panel at once over the last 120 samples it keeps live — two minutes at the default 1 Hz tick, less at a faster one. For anything longer, `R` records the whole session to a `.swr` file as it runs; `--replay` scrubs that back afterward with no length limit, and `S` dumps the current snapshot to disk.
 
+For recording without sitting at the terminal, `syswatch --record --keep 24h` runs headless (no TUI) and writes rotating hourly chunk files, pruning anything older than `--keep` (`30m` / `24h` / `7d` — any number plus s/m/h/d) as new ones are written. It's a plain foreground process — run it under `nohup`, a terminal multiplexer, or a user-level systemd/launchd unit if you want it to outlive your session; syswatch doesn't install anything or listen on the network on its own. `Ctrl-C` flushes the current chunk and exits cleanly. Recordings from `--record` land in a separate directory from `R`'s interactive ones, so an unattended run and a manual one you're keeping on purpose never collide or get pruned into each other.
+
 **Honest about platform limits.** Where data needs sudo (`powermetrics` for fans, per-component power, GPU util on Apple Silicon) the tab shows what we *can* get for free and a one-line note about what's gated. Nothing is faked, nothing prompts.
 
 ## Anti-goals
 
 - **Not multi-host.** For fleet view, use NetWatch's web dashboard.
-- **Not a daemon.** No long-running collector, no Prometheus push. The session is the database.
+- **No privileged daemon, no network exposure.** `--record --keep` can run for as long as you leave it, but it's a plain foreground process you start -- nothing gets installed, nothing listens on the network, no Prometheus endpoint. A recording is a file, not a database with a query API.
 - **Not interactive remediation.** Read-only, deliberately. We don't kill, renice, unmount, or restart.
 - **Not a logging product.** We surface OOM kills as a *signal* in Memory; we are not a log search UI.
 - **Not pretty charts for screenshots.** Block sparklines, real numbers, no smooth curves, no themes-of-the-week.
 
 ## Scope
 
-All twelve tabs render real data on macOS and Linux. Cross-platform collection via `sysinfo`; aggregate disk IO routes through [`netwatch-sdk`](https://github.com/matthart1983/netwatch-sdk) so SysWatch and the NetWatch agent share a single source of truth. Recording/Replay (`R` / `--replay`), Settings (`,`), Help (`?`), table filter (`/` or `f`, on Procs / Memory / Services), themes (`t`), the Lite view (`L` / `--lite`), the Dense view (`V` / `--dense`), and the graph-fade rendering are all live.
+All twelve tabs render real data on macOS and Linux. Cross-platform collection via `sysinfo`; aggregate disk IO routes through [`netwatch-sdk`](https://github.com/matthart1983/netwatch-sdk) so SysWatch and the NetWatch agent share a single source of truth. Recording/Replay (`R` / `--replay`), unattended recording (`--record` / `--keep`), Settings (`,`), Help (`?`), table filter (`/` or `f`, on Procs / Memory / Services), themes (`t`), the Lite view (`L` / `--lite`), the Dense view (`V` / `--dense`), and the graph-fade rendering are all live.
 
 Lite's temp / fan / power vitals depend on platform sensors: Linux reads `/sys/class/hwmon`, `/sys/class/thermal` and RAPL; macOS needs IOKit/SMC access, so on Apple Silicon those three commonly render `--` while CPU, memory, disk and processes remain fully live.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,8 @@
 use std::io;
+use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{
@@ -30,14 +31,26 @@ pub struct Options {
     /// Source of truth for tick_ms / theme / graph_style / default_tab.
     /// CLI overrides are applied to this struct in main() before handoff.
     pub config: SyswatchConfig,
-    /// Pre-loaded snapshots from a `--replay` invocation. When Some,
-    /// the run loop skips live collection entirely and the user
-    /// scrubs through the recorded ticks instead.
-    pub replay: Option<Vec<Snapshot>>,
+    /// A `--replay` invocation. When Some, the run loop skips live
+    /// collection entirely and the user scrubs through the recorded
+    /// ticks instead. `total` is a cheap pre-count (`recording::count`)
+    /// so `History`'s rings can be sized correctly up front without
+    /// ever materializing the whole recording into a `Vec<Snapshot>` --
+    /// `run()` streams it tick by tick from `recording::RecordingReader`
+    /// straight into `History::push`.
+    pub replay: Option<ReplaySource>,
     /// Start in the Lite view (`--lite`). Opt-in only.
     pub lite: bool,
     /// Start in the Dense view. Overrides `view` in config.toml for this run.
     pub dense: bool,
+}
+
+/// A `--replay` target: the recording's path plus a cheap pre-count of
+/// how many ticks it holds, so the caller can size `History`'s rings
+/// before streaming the file in.
+pub struct ReplaySource {
+    pub path: PathBuf,
+    pub total: usize,
 }
 
 /// Number of CPU-usage samples kept per process for the inline Procs sparkline.
@@ -1261,27 +1274,42 @@ pub fn run(opts: Options) -> Result<()> {
         app.view_mode = ViewMode::Dense;
     }
 
-    // Populate History from the recording up front, then plant the
-    // scrubber at oldest tick so the user sees the start. Live
-    // collection is skipped entirely in replay mode.
-    if let Some(snaps) = opts.replay {
+    // Stream the recording straight into History, one tick at a time,
+    // rather than collecting it into a `Vec<Snapshot>` first and then
+    // cloning every entry again on the way into the rings -- with a
+    // known `total` (a cheap pre-count from the caller) the rings are
+    // sized correctly up front, so there's still no eviction of the
+    // recording's head, just without ever holding two full copies of
+    // it in memory at once. Live collection is skipped entirely in
+    // replay mode.
+    if let Some(source) = opts.replay {
         app.replay_mode = true;
         // Resize the History rings if needed so the entire recording
         // fits — default cap is 120 ticks; sessions longer than that
         // would otherwise lose the head on push.
-        let needed = snaps.len().max(120);
+        let needed = source.total.max(120);
         app.history = History::new(needed);
-        for s in &snaps {
-            app.history.push(s);
+        match crate::recording::RecordingReader::open(&source.path) {
+            Ok(reader) => {
+                for s in reader {
+                    app.history.push(&s);
+                }
+            }
+            Err(e) => {
+                // Header-level errors (bad magic, wrong version) surface
+                // here rather than at the earlier count() call if the
+                // file changed between the two -- vanishingly unlikely,
+                // but fail loudly rather than silently replaying nothing.
+                return Err(e).context("re-opening recording for replay");
+            }
         }
         // Park scrubber at the oldest tick so the user explores
         // forward through the recording.
         app.scrub_offset = app.history.session.len().saturating_sub(1);
-        app.snap = snaps.last().cloned();
-        app.insights = if let Some(last) = snaps.last() {
-            insights::compute(&app.history, last)
-        } else {
-            Vec::new()
+        app.snap = app.history.session.nth_back(0).cloned();
+        app.insights = match app.history.session.nth_back(0) {
+            Some(last) => insights::compute(&app.history, last),
+            None => Vec::new(),
         };
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,22 @@ struct Cli {
     /// Replay a previously-recorded session (.swr file, written by
     /// pressing `R` during a live run). No live collection happens —
     /// arrow keys / Home / End scrub through the recorded ticks.
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", conflicts_with = "record")]
     replay: Option<std::path::PathBuf>,
+
+    /// Record continuously in the background, no TUI: sample on --tick
+    /// (or the saved config's tick), write into rotating chunk files
+    /// under the data directory, and prune chunks older than --keep as
+    /// new ones start. Runs until interrupted (Ctrl-C / SIGTERM),
+    /// which flushes the current chunk before exiting. Requires --keep.
+    #[arg(long, requires = "keep")]
+    record: bool,
+
+    /// How much history an unattended --record run retains on disk.
+    /// A number plus a unit: seconds/minutes/hours/days, e.g. "24h",
+    /// "7d", "90m". Meaningless without --record.
+    #[arg(long, value_name = "DURATION", value_parser = recording::parse_retention, requires = "record")]
+    keep: Option<std::time::Duration>,
 }
 
 fn main() -> Result<()> {
@@ -59,19 +73,47 @@ fn main() -> Result<()> {
         cfg.validate();
     }
 
+    // --record is a headless mode: no TUI, no theme, no tab -- dispatch
+    // to it before any of that setup runs. `requires = "keep"` on the
+    // clap arg means `cli.keep` is always Some here.
+    if cli.record {
+        let keep = cli.keep.expect("clap requires --keep with --record");
+        let ring_dir = recording::ring_dir()
+            .ok_or_else(|| anyhow::anyhow!("could not determine the data directory"))?;
+        let tick = std::time::Duration::from_millis(cfg.tick_ms.clamp(100, 5000));
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let stop = std::sync::Arc::clone(&stop);
+            ctrlc::set_handler(move || {
+                stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            })
+            .map_err(|e| anyhow::anyhow!("could not install Ctrl-C handler: {e}"))?;
+        }
+
+        eprintln!(
+            "syswatch: recording to {} (keeping {:?}, Ctrl-C to stop)",
+            ring_dir.display(),
+            keep
+        );
+        return recording::run_ring(&ring_dir, keep, recording::RING_CHUNK_DURATION, tick, &stop);
+    }
+
     // Apply theme before any rendering so the first frame uses it.
     ui::theme::set_by_name(&cfg.theme);
 
     // CLI --tab wins; otherwise fall back to the persisted default.
     let start_tab = cli.tab.or_else(|| Some(cfg.default_tab.clone()));
 
-    // Replay mode: load the recording and hand it to the run loop
-    // instead of opening a live Collector. Default-tab override goes
+    // Replay mode: a cheap pre-count sizes History's rings, then the
+    // run loop streams the recording in tick by tick via
+    // `RecordingReader` -- never a `Vec<Snapshot>` materializing the
+    // whole file here just to hand it off. Default-tab override goes
     // to Timeline since that's where scrubbing lives.
     let replay = if let Some(path) = cli.replay {
-        let snaps = recording::read(&path)
+        let total = recording::count(&path)
             .map_err(|e| anyhow::anyhow!("could not read recording {}: {}", path.display(), e))?;
-        if snaps.is_empty() {
+        if total == 0 {
             return Err(anyhow::anyhow!(
                 "recording {} contains no snapshots",
                 path.display()
@@ -79,10 +121,10 @@ fn main() -> Result<()> {
         }
         eprintln!(
             "syswatch: replaying {} snapshots from {}",
-            snaps.len(),
+            total,
             path.display()
         );
-        Some(snaps)
+        Some(app::ReplaySource { path, total })
     } else {
         None
     };

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -55,7 +55,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Local};
@@ -552,8 +552,201 @@ impl Iterator for RecordingReader {
 /// Read every snapshot in a .swr file. Tolerant of truncated tails
 /// (returns what it could parse) so a recording cut off by a crash
 /// is still useful.
+///
+/// Nothing in the binary calls this today -- `--replay` streams via
+/// [`RecordingReader`] directly (see `app::run`) to avoid holding two
+/// full copies of a recording in memory. Kept as the obvious "just
+/// give me the Vec" convenience for a caller that doesn't care about
+/// that, and for the tests in this module, which use it throughout as
+/// the simplest way to assert on what got written.
+#[allow(dead_code)]
 pub fn read(path: &Path) -> Result<Vec<Snapshot>> {
     Ok(RecordingReader::open(path)?.collect())
+}
+
+/// Count the ticks in a .swr file without holding them all in memory
+/// at once -- each decoded `Snapshot` is dropped as soon as it's
+/// counted. Used to size `History`'s rings before streaming a replay
+/// in via [`RecordingReader`] directly, so a caller never needs to
+/// choose between "materialize the whole recording to know its length"
+/// and "guess a size and risk evicting the head." Decodes the file
+/// twice in total across both calls (this one, then the real replay
+/// pass) -- real CPU cost, but decoding is fast and the file is small
+/// (v3's whole point), so it's cheap next to holding two full copies
+/// of a long recording in memory.
+pub fn count(path: &Path) -> Result<usize> {
+    Ok(RecordingReader::open(path)?.count())
+}
+
+// ── Unattended recording (`syswatch --record --keep`) ──────────────────
+
+/// Directory for `--record`'s rotating chunk files. Separate from
+/// [`dir`] (the interactive `R`-key recordings) so the two never
+/// collide or get pruned into each other -- an unattended recording
+/// and a manual one you're keeping on purpose are different things.
+pub fn ring_dir() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|d| d.join("syswatch").join("ring"))
+}
+
+/// How long each rotated chunk file covers before a new one starts.
+/// Small enough that `--keep` prunes in reasonably fine steps (up to
+/// one chunk's worth of slack past the requested window, not a whole
+/// day of it); large enough that a week of retention is a few dozen
+/// files, not thousands.
+pub const RING_CHUNK_DURATION: Duration = Duration::from_secs(3600);
+
+fn fresh_chunk_path(ring_dir: &Path, seq: u64) -> PathBuf {
+    // The timestamp is for a human `ls`-ing the directory; `seq` is
+    // what actually guarantees uniqueness. Two rotations landing in
+    // the same wall-clock second can't happen at the real 1-hour
+    // chunk_duration, but a short chunk_duration (tests; a future
+    // `--chunk` override) or a clock that jumps backward would
+    // otherwise collide on `Recorder::create`'s `create_new(true)`.
+    let ts: DateTime<Local> = SystemTime::now().into();
+    ring_dir.join(format!(
+        "chunk-{}-{:06}.swr",
+        ts.format("%Y-%m-%dT%H-%M-%S"),
+        seq
+    ))
+}
+
+/// Parse a retention duration like `"24h"`, `"7d"`, `"90m"`, `"3600s"`
+/// -- a number followed by a single unit letter.
+pub fn parse_retention(s: &str) -> Result<Duration> {
+    let s = s.trim();
+    if s.len() < 2 {
+        return Err(anyhow!(
+            "invalid duration '{s}' -- expected a number followed by s/m/h/d, e.g. '24h'"
+        ));
+    }
+    let (num_str, unit) = s.split_at(s.len() - 1);
+    let n: u64 = num_str.parse().map_err(|_| {
+        anyhow!("invalid duration '{s}' -- expected a number followed by s/m/h/d, e.g. '24h'")
+    })?;
+    let secs = match unit {
+        "s" => n,
+        "m" => n.saturating_mul(60),
+        "h" => n.saturating_mul(3600),
+        "d" => n.saturating_mul(86400),
+        other => {
+            return Err(anyhow!(
+                "invalid duration unit '{other}' in '{s}' -- expected s/m/h/d, e.g. '24h'"
+            ))
+        }
+    };
+    if secs == 0 {
+        return Err(anyhow!("retention duration must be greater than zero"));
+    }
+    Ok(Duration::from_secs(secs))
+}
+
+/// Remove chunk files in `ring_dir` whose mtime is older than `keep`.
+/// A chunk's mtime is its last-written time -- roughly when its
+/// newest data was captured, since nothing appends to a chunk again
+/// once it's rotated out. The single most recent chunk is never
+/// removed even if it's individually older than `keep`, so a
+/// recorder that's been paused or a `--keep` shorter than one chunk
+/// can't prune away the only file that exists. Returns the number of
+/// files removed.
+fn prune_chunks(ring_dir: &Path, keep: Duration) -> Result<usize> {
+    let mut entries: Vec<(PathBuf, SystemTime)> = fs::read_dir(ring_dir)
+        .context("listing ring directory")?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "swr"))
+        .filter_map(|e| {
+            e.metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(|t| (e.path(), t))
+        })
+        .collect();
+    entries.sort_by_key(|(_, t)| *t);
+
+    let cutoff = SystemTime::now()
+        .checked_sub(keep)
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let keepable = entries.len().saturating_sub(1);
+    let mut removed = 0;
+    for (path, mtime) in entries.into_iter().take(keepable) {
+        if mtime < cutoff {
+            fs::remove_file(&path)
+                .with_context(|| format!("removing expired chunk {}", path.display()))?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+/// Run the unattended recorder: sample on `tick`, write into
+/// rotating chunk files under `ring_dir` (a new one every
+/// `chunk_duration`), and prune chunks older than `keep` each time a
+/// new one starts. Runs until `stop` is set to `true` -- the real
+/// entry point (`main.rs`) sets that from a Ctrl-C/SIGTERM handler;
+/// tests set it directly, no signal handling involved.
+///
+/// Flushes the current chunk on every exit path (the loop ending, or
+/// an error partway through), since losing an unattended recording's
+/// last few minutes to an ungraceful stop would defeat the point of
+/// the feature.
+pub fn run_ring(
+    ring_dir: &Path,
+    keep: Duration,
+    chunk_duration: Duration,
+    tick: Duration,
+    stop: &std::sync::atomic::AtomicBool,
+) -> Result<()> {
+    use std::sync::atomic::Ordering;
+
+    fs::create_dir_all(ring_dir).context("creating ring directory")?;
+
+    let mut collector = crate::collect::Collector::new(tick.as_millis() as u64);
+    let mut current: Option<Recorder> = None;
+    let mut chunk_started = Instant::now();
+    let mut chunk_seq: u64 = 0;
+    // Poll `stop` at a finer grain than `tick` so a request to stop is
+    // noticed promptly even at a slow (e.g. 5s) sample rate, without
+    // busy-waiting between samples.
+    const STOP_POLL: Duration = Duration::from_millis(200);
+    let mut next_sample = Instant::now();
+
+    let result = (|| -> Result<()> {
+        while !stop.load(Ordering::Relaxed) {
+            let now = Instant::now();
+            if now < next_sample {
+                std::thread::sleep(STOP_POLL.min(next_sample - now));
+                continue;
+            }
+
+            if current.is_none() || now.duration_since(chunk_started) >= chunk_duration {
+                // Dropping the old recorder (if any) flushes its final
+                // block before the new one is created.
+                current = None;
+                current = Some(Recorder::create(fresh_chunk_path(ring_dir, chunk_seq))?);
+                chunk_seq += 1;
+                chunk_started = now;
+                prune_chunks(ring_dir, keep)?;
+            }
+
+            let snap = collector.sample();
+            if let Some(rec) = current.as_mut() {
+                // A single failed push (e.g. a transient disk error)
+                // doesn't tear down an unattended recorder meant to
+                // run for hours -- log it and keep sampling; the next
+                // chunk rotation gets a fresh file and fresh chance.
+                if let Err(e) = rec.push(&snap) {
+                    eprintln!("syswatch: recording write failed: {e}");
+                }
+            }
+            next_sample = now + tick;
+        }
+        Ok(())
+    })();
+
+    // Explicit drop (rather than relying on scope end) so the final
+    // flush happens before `run_ring` returns, whether it's returning
+    // Ok (stop was requested) or Err (a chunk-rotation failure).
+    drop(current);
+    result
 }
 
 #[cfg(test)]
@@ -810,5 +1003,228 @@ mod tests {
         drop(f);
         let snaps = read(&path).unwrap();
         assert_eq!(snaps.len(), 1);
+    }
+
+    // ── count() ──────────────────────────────────────────────────────
+
+    #[test]
+    fn count_matches_read_len_without_materializing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("count.swr");
+        {
+            let mut rec = Recorder::create(path.clone()).unwrap();
+            for i in 0..7u64 {
+                rec.push(&snap_at(i)).unwrap();
+            }
+        }
+        assert_eq!(count(&path).unwrap(), 7);
+        assert_eq!(count(&path).unwrap(), read(&path).unwrap().len());
+    }
+
+    // ── parse_retention ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_retention_accepts_each_unit() {
+        assert_eq!(parse_retention("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(
+            parse_retention("45m").unwrap(),
+            Duration::from_secs(45 * 60)
+        );
+        assert_eq!(
+            parse_retention("24h").unwrap(),
+            Duration::from_secs(24 * 3600)
+        );
+        assert_eq!(
+            parse_retention("7d").unwrap(),
+            Duration::from_secs(7 * 86400)
+        );
+    }
+
+    #[test]
+    fn parse_retention_rejects_garbage() {
+        assert!(parse_retention("").is_err());
+        assert!(parse_retention("24").is_err()); // no unit
+        assert!(parse_retention("h").is_err()); // no number
+        assert!(parse_retention("24x").is_err()); // unknown unit
+        assert!(parse_retention("-5h").is_err()); // negative
+        assert!(parse_retention("0h").is_err()); // zero
+    }
+
+    // ── prune_chunks ─────────────────────────────────────────────────
+
+    fn touch_chunk(dir: &Path, name: &str, age: Duration) {
+        let path = dir.join(name);
+        fs::write(&path, b"x").unwrap();
+        let mtime = SystemTime::now().checked_sub(age).unwrap();
+        let file = File::options().write(true).open(&path).unwrap();
+        file.set_modified(mtime).unwrap();
+    }
+
+    #[test]
+    fn prune_chunks_removes_only_expired_ones() {
+        let dir = tempfile::tempdir().unwrap();
+        touch_chunk(dir.path(), "chunk-old.swr", Duration::from_secs(3600 * 30));
+        touch_chunk(dir.path(), "chunk-mid.swr", Duration::from_secs(3600 * 20));
+        touch_chunk(dir.path(), "chunk-new.swr", Duration::from_secs(60));
+        // Not a .swr file -- must survive regardless of age.
+        touch_chunk(dir.path(), "notes.txt", Duration::from_secs(3600 * 100));
+
+        let removed = prune_chunks(dir.path(), Duration::from_secs(3600 * 24)).unwrap();
+        assert_eq!(removed, 1);
+        let remaining: Vec<String> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(!remaining.contains(&"chunk-old.swr".to_string()));
+        assert!(remaining.contains(&"chunk-mid.swr".to_string()));
+        assert!(remaining.contains(&"chunk-new.swr".to_string()));
+        assert!(remaining.contains(&"notes.txt".to_string()));
+    }
+
+    #[test]
+    fn prune_chunks_never_removes_the_last_survivor() {
+        // A single ancient chunk -- e.g. a recorder that's been paused,
+        // or a --keep shorter than one chunk_duration -- must not be
+        // pruned away to zero files.
+        let dir = tempfile::tempdir().unwrap();
+        touch_chunk(
+            dir.path(),
+            "chunk-only.swr",
+            Duration::from_secs(3600 * 1000),
+        );
+        let removed = prune_chunks(dir.path(), Duration::from_secs(1)).unwrap();
+        assert_eq!(removed, 0);
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    // ── run_ring ─────────────────────────────────────────────────────
+
+    /// Blocks until at least one `.swr` file exists in `dir`, or panics
+    /// after `timeout`. Every `run_ring` test needs this instead of a
+    /// bare fixed sleep-then-stop: a thread spawn's actual scheduling
+    /// delay is not bounded, especially on a loaded machine, so
+    /// "sleep N ms, assume the thread has done useful work by now" is
+    /// inherently racy. Waiting for observable filesystem evidence
+    /// that the thread has actually started isn't.
+    fn wait_for_first_chunk(dir: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let has_chunk = fs::read_dir(dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .any(|e| e.path().extension().is_some_and(|x| x == "swr"));
+            if has_chunk {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "no chunk file appeared within the timeout"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn ring_recorder_rotates_and_prunes_on_a_short_fast_schedule() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ring_dir = dir.path().to_path_buf();
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_writer = Arc::clone(&stop);
+
+        // Tiny tick and chunk duration so several rotations happen in
+        // well under a second of real test time, and a keep window
+        // short enough that early chunks get pruned during the run.
+        let tick = Duration::from_millis(20);
+        let chunk_duration = Duration::from_millis(60);
+        let keep = Duration::from_millis(150);
+
+        let handle = std::thread::spawn({
+            let ring_dir = ring_dir.clone();
+            move || run_ring(&ring_dir, keep, chunk_duration, tick, &stop)
+        });
+
+        wait_for_first_chunk(&ring_dir);
+        // The thread is confirmed running; this long past chunk_duration
+        // (60ms) gives room for several more rotations regardless of
+        // how slow the first one was to start.
+        std::thread::sleep(Duration::from_millis(500));
+        stop_writer.store(true, Ordering::Relaxed);
+        handle.join().unwrap().unwrap();
+
+        let chunks: Vec<_> = fs::read_dir(&ring_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "swr"))
+            .collect();
+        assert!(
+            !chunks.is_empty(),
+            "expected at least one chunk file after running"
+        );
+        // With a 400ms run and a 60ms chunk_duration, several rotations
+        // should have happened; a 150ms keep window should have pruned
+        // at least the earliest ones rather than keeping all of them.
+        assert!(
+            chunks.len() < 6,
+            "expected pruning to have removed some chunks, found {}",
+            chunks.len()
+        );
+
+        // Every surviving chunk must be a valid, readable recording --
+        // pruning or an interrupted rotation must never leave behind a
+        // file that looks like a chunk but isn't one.
+        for entry in &chunks {
+            let snaps = read(&entry.path()).unwrap();
+            assert!(
+                !snaps.is_empty(),
+                "{:?} decoded to zero snapshots",
+                entry.path()
+            );
+        }
+    }
+
+    #[test]
+    fn ring_recorder_flushes_the_final_partial_chunk_on_stop() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ring_dir = dir.path().to_path_buf();
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_writer = Arc::clone(&stop);
+
+        // Chunk duration longer than the whole run, so everything ends
+        // up buffered in one Recorder's pending block -- stopping must
+        // still flush it rather than leaving an empty or truncated file.
+        let handle = std::thread::spawn({
+            let ring_dir = ring_dir.clone();
+            move || {
+                run_ring(
+                    &ring_dir,
+                    Duration::from_secs(3600),
+                    Duration::from_secs(3600),
+                    Duration::from_millis(15),
+                    &stop,
+                )
+            }
+        });
+
+        wait_for_first_chunk(&ring_dir);
+        // A few more ticks (15ms each) so the chunk holds more than
+        // just whatever the very first sample produced.
+        std::thread::sleep(Duration::from_millis(100));
+        stop_writer.store(true, Ordering::Relaxed);
+        handle.join().unwrap().unwrap();
+
+        let chunks: Vec<_> = fs::read_dir(&ring_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "swr"))
+            .collect();
+        assert_eq!(chunks.len(), 1);
+        let snaps = read(&chunks[0].path()).unwrap();
+        assert!(!snaps.is_empty(), "final chunk was not flushed on stop");
     }
 }


### PR DESCRIPTION
## What

Finishes phase 3 -- the two pieces explicitly deferred out of #28 (the recording format PR): streaming replay off disk instead of collecting into memory first, and a bounded on-disk ring for recording without a TUI.

## Streaming replay

`--replay` used to call `recording::read(path)`, collecting the whole recording into a `Vec<Snapshot>`, then loop over it pushing clones into `History` -- two full copies alive at once, however briefly. Now `main.rs` does a cheap `recording::count(path)` (decodes the file but drops each `Snapshot` immediately, so it's O(1) extra memory, not O(n)) to size `History`'s rings correctly, then `app::run()` streams the file straight from `RecordingReader` into `History::push` one tick at a time. Same result -- nothing is evicted, rings are sized exactly as before -- just without the intermediate `Vec`.

Decodes the file twice in total (count, then stream) -- real CPU cost, but cheap next to holding two full copies of a long recording, especially now that v3 files are small to begin with.

Verified end-to-end via a pty harness against a real recording: loads, Timeline scrubs, no user-visible behavior change.

## Unattended recording: `syswatch --record --keep <duration>`

Runs headless (no TUI), sampling on `--tick` and writing rotating chunk files under `<data dir>/syswatch/ring/` -- a new one every hour, with chunks older than `--keep` pruned as each new one starts. `--keep` takes a number plus a unit (`24h`, `7d`, `90m`), validated by clap's native error reporting. Ctrl-C / SIGTERM flushes the current chunk before exiting instead of losing it to an abrupt kill.

Two real bugs caught during testing, not just written around:
- **Chunk filename collisions.** A human-readable timestamp alone (second granularity) isn't unique enough at a fast rotation schedule (or, in principle, a backward clock jump) -- `Recorder::create`'s `create_new(true)` failed outright on the second rotation in the same second. Fixed with a monotonic sequence number in the filename.
- **A real race in the tests themselves.** The first version of the `run_ring` tests used a fixed sleep before setting the stop flag, assuming the spawned thread would have done useful work by then -- not guaranteed on a loaded machine, and it failed. Fixed by polling for the first chunk file to actually appear before proceeding, rather than trusting a wall-clock duration.

`run_ring` takes `ring_dir`, `chunk_duration`, and the stop flag as parameters (not hardcoded), specifically so tests run on a schedule of tens of milliseconds instead of the real 1-hour default.

README: corrected the "Not a daemon" anti-goal, which this feature directly contradicts as worded -- replaced with "no privileged daemon, no network exposure" (still true: it's a plain foreground process, nothing gets installed or listens on the network).

## Verified

- `cargo fmt --check` clean
- `cargo build --release` clean (same 3 pre-existing warnings)
- `cargo test` -- 377 passed / 1 ignored (was 370; 9 new tests, the two `run_ring` tests each run individually 3x plus together with default parallelism to confirm the race fix holds)
- `cargo clippy --all-targets` -- identical total warning count (35), zero in any touched file
- Manual: clap correctly rejects `--record` without `--keep`, `--keep` without `--record`, `--record` with `--replay`, and a malformed `--keep` value, each with a clear message. A real 3-second recording at a 200ms tick produced a chunk decoding to 14 ticks, 215 real processes, 222 real services. SIGINT during that run exited 0 with a complete, valid chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GESiHAfqp3qjvScRBjYu1A
