### PR TITLE
fix(insights): report a real elapsed window in the live TUI

### DIFF
--- a/src/insights/mod.rs
+++ b/src/insights/mod.rs
@@ -45,26 +45,35 @@ pub struct Insight {
 const MIB: u64 = 1024 * 1024;
 const GIB: u64 = 1024 * 1024 * 1024;
 
-/// Real elapsed time between `snap` (the current tick) and the sample at
-/// `baseline_idx` in the *oldest-to-newest* ordering a caller already used
-/// to pull a metric's own baseline value out of e.g. `h.swap.to_vec()`.
+/// Real elapsed time between `snap` (the current tick) and the sample
+/// `n_back` ticks before it, counting back from the newest (0 = `snap`'s
+/// own tick).
 ///
-/// `h.session` is pushed in lockstep with every other per-tick ring (same
-/// `History::push` call, same length always), so the same index lines up
-/// exactly -- read here by reference via `nth_back` rather than cloning the
-/// ring, since each entry is a full `Snapshot` including every process's
-/// name and command line. Reads the actual recorded timestamps rather than
+/// Callers pick their baseline out of a metric series (`h.swap.to_vec()`,
+/// `h.mem.to_vec()`, ...) and so hold an index into *that* ring; they must
+/// convert it to a distance from the newest sample before calling. The
+/// session ring and the metric series are pushed in lockstep but are
+/// deliberately different lengths -- `History::new` caps `session` at `cap`
+/// while every metric series gets `cap.max(SERIES_CAP)`, because a
+/// `Snapshot` costs upwards of 100 KB apiece. A raw series index passed in
+/// here would address the wrong end of the session ring.
+///
+/// Read by reference via `nth_back` rather than cloning the ring, for that
+/// same size reason. Reads the actual recorded timestamps rather than
 /// assuming every tick took the configured interval, so the reported
 /// window stays honest across a live tick-rate change or a replay recorded
 /// at a different rate than it was captured at.
-fn elapsed_secs_since(h: &History, snap: &Snapshot, baseline_idx: usize) -> u64 {
+///
+/// When the window reaches further back than the session ring still
+/// retains, the oldest retained sample answers instead: a window shorter
+/// than the truth, but a real measured one rather than a nonsensical 0.
+fn elapsed_secs_since(h: &History, snap: &Snapshot, n_back: usize) -> u64 {
     let len = h.session.len();
     if len == 0 {
         return 0;
     }
-    let n = len.saturating_sub(1).saturating_sub(baseline_idx);
     h.session
-        .nth_back(n)
+        .nth_back(n_back.min(len - 1))
         .map(|old| snap.t.duration_since(old.t).unwrap_or_default().as_secs())
         .unwrap_or(0)
 }
@@ -252,7 +261,7 @@ fn insight_swap_thrash(h: &History, snap: &Snapshot) -> Option<Insight> {
     let baseline_idx = history.len().saturating_sub(30);
     let baseline = history[baseline_idx];
     let growth = now.saturating_sub(baseline);
-    let elapsed_secs = elapsed_secs_since(h, snap, baseline_idx);
+    let elapsed_secs = elapsed_secs_since(h, snap, history.len() - 1 - baseline_idx);
 
     let (severity, title) = if growth >= 512 * MIB {
         (
@@ -447,7 +456,7 @@ fn insight_memory_pressure(h: &History, snap: &Snapshot) -> Option<Insight> {
     } else {
         return None;
     };
-    let elapsed_secs = elapsed_secs_since(h, snap, baseline_idx);
+    let elapsed_secs = elapsed_secs_since(h, snap, last_n - 1);
     Some(Insight {
         severity,
         title: format!(
@@ -570,8 +579,7 @@ fn insight_gpu_pegged(h: &History, snap: &Snapshot) -> Option<Insight> {
     } else {
         return None;
     };
-    let baseline_idx = recent.len() - last_n;
-    let elapsed_secs = elapsed_secs_since(h, snap, baseline_idx);
+    let elapsed_secs = elapsed_secs_since(h, snap, last_n - 1);
     let busiest = snap
         .gpus
         .iter()
@@ -918,6 +926,34 @@ mod tests {
         let result = compute(&h, &s);
         let ins = first_with(&result, "swap").expect("swap insight expected");
         assert_eq!(ins.severity, Severity::Crit);
+    }
+
+    #[test]
+    fn swap_thrash_window_stays_real_after_session_eviction() {
+        // Regression: the card used to read "in last 0s" once the swap series
+        // outgrew the session ring -- minutes into any live run.
+        let mut h = History::new(10);
+        let t0 = std::time::SystemTime::UNIX_EPOCH;
+        for i in 0..60u64 {
+            h.push(&Snapshot {
+                t: t0 + Duration::from_secs(i),
+                mem: mem(0, 16 * GIB, 100 * MIB, 4 * GIB),
+                ..Default::default()
+            });
+        }
+        let s = Snapshot {
+            t: t0 + Duration::from_secs(60),
+            mem: mem(0, 16 * GIB, 700 * MIB, 4 * GIB),
+            ..Default::default()
+        };
+        h.push(&s);
+        let ins = first_with(&compute(&h, &s), "swap").expect("swap insight expected");
+        // The session ring holds t=51..60, so the 30-tick window clamps to 9s.
+        assert!(
+            ins.title.contains("in last 9s"),
+            "expected a real window, got: {}",
+            ins.title
+        );
     }
 
     // ── runaway_proc (uses History::proc_cpu_ewma) ────────────────────────
@@ -1293,10 +1329,37 @@ mod tests {
             t: t0 + Duration::from_secs(4 * 4),
             ..Default::default()
         };
-        // baseline_idx 0 = the oldest of the 5 pushed ticks (t=0s).
-        assert_eq!(elapsed_secs_since(&h, &now, 0), 16);
-        // baseline_idx 3 = the 4th pushed tick (t=12s) -- 4s before now.
-        assert_eq!(elapsed_secs_since(&h, &now, 3), 4);
+        // 4 back = the oldest of the 5 pushed ticks (t=0s).
+        assert_eq!(elapsed_secs_since(&h, &now, 4), 16);
+        // 1 back = the 4th pushed tick (t=12s) -- 4s before now.
+        assert_eq!(elapsed_secs_since(&h, &now, 1), 4);
+    }
+
+    #[test]
+    fn elapsed_secs_since_survives_session_ring_eviction() {
+        // The live TUI runs `History::new(120)`: 120 snapshots in the session
+        // ring, but 2048 samples in every metric series. After a couple of
+        // minutes a metric window reaches back past what the session ring
+        // still holds, and the answer has to stay a real measured number.
+        let mut h = History::new(10);
+        let t0 = std::time::SystemTime::UNIX_EPOCH;
+        for i in 0..40u64 {
+            h.push(&Snapshot {
+                t: t0 + Duration::from_secs(i),
+                ..Default::default()
+            });
+        }
+        // Series kept all 40 samples; the session ring kept only t=30..39.
+        assert_eq!(h.mem.len(), 40);
+        assert_eq!(h.session.len(), 10);
+        let now = Snapshot {
+            t: t0 + Duration::from_secs(39),
+            ..Default::default()
+        };
+        // Inside the session ring: exact.
+        assert_eq!(elapsed_secs_since(&h, &now, 5), 5);
+        // Past its oldest sample (t=30s): clamped to 9s, not 0.
+        assert_eq!(elapsed_secs_since(&h, &now, 30), 9);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #27. The elapsed-time helper it introduced indexes the wrong ring, so every insight card that reports a window reads `0s` in the live TUI within about two minutes of launch.

## The bug

`elapsed_secs_since` took an index into a metric series but converted it to a distance-from-newest using `h.session.len()`. Those rings are deliberately different lengths — `History::new(cap)` caps `session` at `cap` while every metric series gets `cap.max(SERIES_CAP)`, because a `Snapshot` costs upwards of 100 KB apiece. The live TUI runs `History::new(120)`, so once a series passed ~126 samples the subtraction saturated to 0 and `nth_back(0)` returned the current tick.

Cards affected, permanently after that point:

```
swap thrash — 0.7 GB swapped, +600 MB in last 0s
memory pressure — RAM 96% used over last 0s
100% GPU util sustained over last 0s
```

Detection is unaffected — severity thresholds and culprit attribution read the metric values, not the elapsed window. This is display only, but in the mode users read most.

Only the interactive path was affected: replay (`app.rs`) and the non-interactive reports (`report.rs`) size the session ring to hold every push, so their rings stay the same length. That is also why the existing tests missed it — none pushed past the session cap.

## The fix

The helper now takes a distance from the newest sample; callers convert their own index. A window reaching past what the session ring retains clamps to the oldest retained sample rather than collapsing to zero — shorter than the truth, but measured. The doc comment that asserted the false "same length always" invariant is corrected.

## Tests

Two regression tests that push past the session cap, at helper and card level. Verified the card-level one fails against the old logic with exactly the predicted output (`+600 MB in last 0s`). Full suite: 392 passed, fmt and clippy clean.

## Known remaining

`as_secs()` floors, so at the 100 ms tick floor the 6-sample memory window is 500 ms and still prints `0s`. Separate formatting decision, left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DacWgrTDDE5svX2aGkwnLB